### PR TITLE
fix: disable sourcmap generation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
i havent found any use for them and they end up in the published
package and in the end generate lots of warnings when used in the
streamdeck debugger view