### PR TITLE
fix: validation of key-events

### DIFF
--- a/src/StreamdeckTypes/Sent/BaseKeyType.ts
+++ b/src/StreamdeckTypes/Sent/BaseKeyType.ts
@@ -11,7 +11,7 @@ export const BaseKeyType = Type.Intersect([
       coordinates: Type.Optional(BaseCoordinatesPayloadType),
       isInMultiAction: Type.Boolean(),
       settings: Type.Any(),
-      state: Type.Optional(Type.Number({ maximum: 1, minimum: 0 })),
+      state: Type.Optional(Type.Number({ minimum: 0 })),
       userDesiredState: Type.Optional(Type.Number({ maximum: 1, minimum: 0 })),
     }),
   }),

--- a/test/Events/Received/Plugin/KeyDownEventTest.ts
+++ b/test/Events/Received/Plugin/KeyDownEventTest.ts
@@ -10,6 +10,7 @@ import eventMissingParameter from '../fixtures/keyDownEvent.missing-param.json';
 import eventValid from '../fixtures/keyDownEvent.valid.json';
 import eventValidMultiaction from '../fixtures/keyDownEvent.valid.multiaction.json';
 import eventValidMultiactionState from '../fixtures/keyDownEvent.valid.multiaction.state.json';
+import eventValidStateIs3 from '../fixtures/keyDownEvent.valid.state.is3.json';
 import eventValidState from '../fixtures/keyDownEvent.valid.state.json';
 
 describe('KeyDownEvent test', () => {
@@ -60,6 +61,18 @@ describe('KeyDownEvent test', () => {
     expect(event.isInMultiAction).to.be.true;
     expect(event.state).to.equal(1);
     expect(event.userDesiredState).to.equal(0);
+  });
+  it('should allow the state to be >= 1', function () {
+    const event = new KeyDownEvent(eventValidStateIs3);
+    expect(event.action).to.equal('some.action');
+    expect(event.context).to.equal('ewrwerweerwer');
+    expect(event.device).to.equal('xxzxxzxzxxzxzxz');
+    expect(event.event).to.equal('keyDown');
+    expect(event.column).to.equal(2);
+    expect(event.row).to.equal(2);
+    expect(event.isInMultiAction).to.be.false;
+    expect(event.state).to.equal(3);
+    expect(event.userDesiredState).to.be.undefined;
   });
   it('should throw a validation error on missing keydown parameters', function () {
     expect(() => new KeyDownEvent(eventMissingParameter)).to.throw(EventValidationError, /required property 'context'/);

--- a/test/Events/Received/Plugin/KeyUpEventTest.ts
+++ b/test/Events/Received/Plugin/KeyUpEventTest.ts
@@ -10,6 +10,7 @@ import eventMissingParameter from '../fixtures/keyUpEvent.missing-param.json';
 import eventValid from '../fixtures/keyUpEvent.valid.json';
 import eventValidMultiaction from '../fixtures/keyUpEvent.valid.multiaction.json';
 import eventValidMultiactionState from '../fixtures/keyUpEvent.valid.multiaction.state.json';
+import eventValidStateIs2 from '../fixtures/keyUpEvent.valid.state.is2.json';
 import eventValidState from '../fixtures/keyUpEvent.valid.state.json';
 
 describe('KeyUpEvent test', () => {
@@ -60,6 +61,18 @@ describe('KeyUpEvent test', () => {
     expect(event.isInMultiAction).to.be.true;
     expect(event.state).to.equal(1);
     expect(event.userDesiredState).to.equal(0);
+  });
+  it('should allow the state to be >= 1', function () {
+    const event = new KeyUpEvent(eventValidStateIs2);
+    expect(event.action).to.equal('dev.com.test');
+    expect(event.context).to.equal('fasdasdf');
+    expect(event.device).to.equal('rweqqwer');
+    expect(event.event).to.equal('keyUp');
+    expect(event.column).to.equal(2);
+    expect(event.row).to.equal(2);
+    expect(event.isInMultiAction).to.be.false;
+    expect(event.state).to.equal(2);
+    expect(event.userDesiredState).to.be.undefined;
   });
   it('should throw a validation error on missing keydown parameters', function () {
     expect(() => new KeyUpEvent(eventMissingParameter)).to.throw(EventValidationError, /required property 'column'/);

--- a/test/Events/Received/fixtures/keyDownEvent.valid.state.is3.json
+++ b/test/Events/Received/fixtures/keyDownEvent.valid.state.is3.json
@@ -1,0 +1,15 @@
+{
+  "action": "some.action",
+  "context": "ewrwerweerwer",
+  "device": "xxzxxzxzxxzxzxz",
+  "event": "keyDown",
+  "payload": {
+    "coordinates": {
+      "column": 2,
+      "row": 2
+    },
+    "isInMultiAction": false,
+    "settings": {},
+    "state": 3
+  }
+}

--- a/test/Events/Received/fixtures/keyUpEvent.valid.state.is2.json
+++ b/test/Events/Received/fixtures/keyUpEvent.valid.state.is2.json
@@ -1,0 +1,15 @@
+{
+  "action": "dev.com.test",
+  "context": "fasdasdf",
+  "device": "rweqqwer",
+  "event": "keyUp",
+  "payload": {
+    "coordinates": {
+      "column": 2,
+      "row": 2
+    },
+    "isInMultiAction": false,
+    "settings": {},
+    "state": 2
+  }
+}


### PR DESCRIPTION
now we allow the state to be any number greater than 0 (from max 1),
as there can be more than two states