### PR TITLE
Initial Stream Deck+ Support Pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test-coverage": "nyc yarn test"
   },
   "dependencies": {
-    "@sinclair/typebox": "0.24.48",
+    "@sinclair/typebox": "0.24.49",
     "ajv": "^8.6.2"
   },
   "devDependencies": {

--- a/src/Events/EventsSent.ts
+++ b/src/Events/EventsSent.ts
@@ -101,10 +101,42 @@ export default class EventsSent {
     return new SwitchToProfileEvent(profile, context, device);
   }
 
+  /**
+   * Send a command to the Stream Deck to update the Feedback displayed for a specific dial.
+   *
+   * SetFeedbackEvent's payload takes a key-value record of properties that will require some care to be taken, as it is
+   * not particularly type safe. Developers are encouraged to either use built-in layout types or define their own types
+   * for use in this event. As a general rule though, this payload works as follows:
+   * - Keys in the object represent the element in the feedback that will be modified
+   * - Values in the object will generally be an object that represents the changes that should be made to an element,
+   *   based on the element's type.
+   * - Values may also be a string or number, which will directly set the `value` of the associated element.
+   * - The keys `title` and `icon` can *only* have the value updated, either through direct assignment or by an object
+   *   containing a `value` key.
+   * - Unrecognized keys and values are ignored with no notification or error.
+   *
+   * To create custom feedback types, please refer to {@link LayoutA0Feedback} et al.
+   *
+   * @param payload The feedback object to send to the Stream Deck, based on at least GenericLayoutFeedback.
+   * @param context The opaque context representing the Stream Deck dial that needs to be updated.
+   */
   public setFeedback(payload: LayoutFeedback | GenericLayoutFeedback, context: string) {
     return new SetFeedbackEvent(payload, context);
   }
 
+  /**
+   * Send a command to the Stream Deck to update the Feedback Layout for a specific dial.
+   *
+   * The Stream Deck application ships with a number of layouts built-in (see {@link LayoutFeedbackKey} for this list),
+   * but custom layouts may be created and stored in the plugin archive which may then be used. An invalid feedback
+   * layout will fall back to only displaying the title and icon.
+   *
+   * Changing the layout feedback *will* reset all feedback currently on the device, so developers need to take care
+   * to repopulate feedback (if necessary) after sending this command.
+   *
+   * @param layout A layout key or path (relative to the plugin's root) to use as the layout for this dial.
+   * @param context The opaque context representing the Stream Deck dial that needs to be updated.
+   */
   public setFeedbackLayout(layout: LayoutFeedbackKey | string, context: string) {
     return new SetFeedbackLayoutEvent(layout, context);
   }

--- a/src/Events/EventsSent.ts
+++ b/src/Events/EventsSent.ts
@@ -17,9 +17,10 @@ import {
   SetFeedbackLayoutEvent,
   SetImageEvent,
   SetTitleEvent,
-  TargetEnum
+  TargetEnum,
 } from '@/Events/Sent/Plugin';
 import { SendToPluginEvent } from '@/Events/Sent/PropertyInspector';
+import { LayoutFeedback } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback';
 
 type TargetType = 'both' | 'hardware' | 'software';
 
@@ -96,7 +97,7 @@ export default class EventsSent {
     return new SwitchToProfileEvent(profile, context, device);
   }
 
-  public setFeedback(payload: unknown, context: string) {
+  public setFeedback(payload: LayoutFeedback, context: string) {
     return new SetFeedbackEvent(payload, context);
   }
 

--- a/src/Events/EventsSent.ts
+++ b/src/Events/EventsSent.ts
@@ -101,7 +101,7 @@ export default class EventsSent {
     return new SetFeedbackEvent(payload, context);
   }
 
-  public setFeedbackLayout(layout: LayoutFeedbackKey | string, context: string) {
+  public setFeedbackLayout(layout: LayoutFeedbackKey, context: string) {
     return new SetFeedbackLayoutEvent(layout, context);
   }
 }

--- a/src/Events/EventsSent.ts
+++ b/src/Events/EventsSent.ts
@@ -20,7 +20,11 @@ import {
   TargetEnum,
 } from '@/Events/Sent/Plugin';
 import { SendToPluginEvent } from '@/Events/Sent/PropertyInspector';
-import { LayoutFeedback, LayoutFeedbackKey } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback';
+import {
+  GenericLayoutFeedback,
+  LayoutFeedback,
+  LayoutFeedbackKey,
+} from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback';
 
 type TargetType = 'both' | 'hardware' | 'software';
 
@@ -97,11 +101,11 @@ export default class EventsSent {
     return new SwitchToProfileEvent(profile, context, device);
   }
 
-  public setFeedback(payload: LayoutFeedback, context: string) {
+  public setFeedback(payload: LayoutFeedback | GenericLayoutFeedback, context: string) {
     return new SetFeedbackEvent(payload, context);
   }
 
-  public setFeedbackLayout(layout: LayoutFeedbackKey, context: string) {
+  public setFeedbackLayout(layout: LayoutFeedbackKey | string, context: string) {
     return new SetFeedbackLayoutEvent(layout, context);
   }
 }

--- a/src/Events/EventsSent.ts
+++ b/src/Events/EventsSent.ts
@@ -20,7 +20,7 @@ import {
   TargetEnum,
 } from '@/Events/Sent/Plugin';
 import { SendToPluginEvent } from '@/Events/Sent/PropertyInspector';
-import { LayoutFeedback } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback';
+import { LayoutFeedback, LayoutFeedbackKey } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback';
 
 type TargetType = 'both' | 'hardware' | 'software';
 
@@ -101,7 +101,7 @@ export default class EventsSent {
     return new SetFeedbackEvent(payload, context);
   }
 
-  public setFeedbackLayout(layout: string, context: string) {
+  public setFeedbackLayout(layout: LayoutFeedbackKey | string, context: string) {
     return new SetFeedbackLayoutEvent(layout, context);
   }
 }

--- a/src/Events/EventsSent.ts
+++ b/src/Events/EventsSent.ts
@@ -11,7 +11,14 @@ import {
   ShowOkEvent,
   SwitchToProfileEvent,
 } from '@/Events/Sent';
-import { SendToPropertyInspectorEvent, SetImageEvent, SetTitleEvent, TargetEnum } from '@/Events/Sent/Plugin';
+import {
+  SendToPropertyInspectorEvent,
+  SetFeedbackEvent,
+  SetFeedbackLayoutEvent,
+  SetImageEvent,
+  SetTitleEvent,
+  TargetEnum
+} from '@/Events/Sent/Plugin';
 import { SendToPluginEvent } from '@/Events/Sent/PropertyInspector';
 
 type TargetType = 'both' | 'hardware' | 'software';
@@ -87,5 +94,13 @@ export default class EventsSent {
 
   public switchToProfile(profile: string, context: string, device: string): SwitchToProfileEvent {
     return new SwitchToProfileEvent(profile, context, device);
+  }
+
+  public setFeedback(payload: unknown, context: string) {
+    return new SetFeedbackEvent(payload, context);
+  }
+
+  public setFeedbackLayout(layout: string, context: string) {
+    return new SetFeedbackLayoutEvent(layout, context);
   }
 }

--- a/src/Events/Received/EventFactory.ts
+++ b/src/Events/Received/EventFactory.ts
@@ -83,7 +83,6 @@ export default class EventFactory {
         return new WillDisappearEvent(payload);
       default: // creates a typeerror when we forget to add an event
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        // noinspection JSUnusedLocalSymbols
         const checkIfAllEventsAreUsed: never = event;
         throw new UnknownEventError('unknown event: ' + payload.event + ' in data: ' + JSON.stringify(payload));
     }

--- a/src/Events/Received/EventFactory.ts
+++ b/src/Events/Received/EventFactory.ts
@@ -20,6 +20,7 @@ import {
   WillAppearEvent,
   WillDisappearEvent,
 } from './Plugin';
+import {DialPressEvent, DialRotateEvent, TouchTapEvent} from "@/Events/Received/Plugin/Dial";
 
 type EventNames = ReceivedPluginEventTypes['event'] | ReceivedPropertyInspectorEventTypes['event'];
 
@@ -48,6 +49,10 @@ export default class EventFactory {
         return new DeviceDidConnectEvent(payload);
       case 'deviceDidDisconnect':
         return new DeviceDidDisconnectEvent(payload);
+      case 'dialPress':
+        return new DialPressEvent(payload);
+      case 'dialRotate':
+        return new DialRotateEvent(payload);
       case 'didReceiveSettings':
         return new DidReceiveSettingsEvent(payload);
       case 'didReceiveGlobalSettings':
@@ -68,6 +73,8 @@ export default class EventFactory {
         return new SystemDidWakeUpEvent(payload);
       case 'titleParametersDidChange':
         return new TitleParametersDidChangeEvent(payload);
+      case 'touchTap':
+        return new TouchTapEvent(payload);
       case 'willAppear':
         return new WillAppearEvent(payload);
       case 'willDisappear':

--- a/src/Events/Received/EventFactory.ts
+++ b/src/Events/Received/EventFactory.ts
@@ -10,6 +10,8 @@ import {
   ApplicationDidTerminateEvent,
   DeviceDidConnectEvent,
   DeviceDidDisconnectEvent,
+  DialPressEvent,
+  DialRotateEvent,
   KeyDownEvent,
   KeyUpEvent,
   PropertyInspectorDidAppearEvent,
@@ -17,10 +19,10 @@ import {
   SendToPluginEvent,
   SystemDidWakeUpEvent,
   TitleParametersDidChangeEvent,
+  TouchTapEvent,
   WillAppearEvent,
   WillDisappearEvent,
 } from './Plugin';
-import {DialPressEvent, DialRotateEvent, TouchTapEvent} from "@/Events/Received/Plugin/Dial";
 
 type EventNames = ReceivedPluginEventTypes['event'] | ReceivedPropertyInspectorEventTypes['event'];
 
@@ -81,6 +83,7 @@ export default class EventFactory {
         return new WillDisappearEvent(payload);
       default: // creates a typeerror when we forget to add an event
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        // noinspection JSUnusedLocalSymbols
         const checkIfAllEventsAreUsed: never = event;
         throw new UnknownEventError('unknown event: ' + payload.event + ' in data: ' + JSON.stringify(payload));
     }

--- a/src/Events/Received/Plugin/AbstractVisibilityEvent.ts
+++ b/src/Events/Received/Plugin/AbstractVisibilityEvent.ts
@@ -1,0 +1,11 @@
+import AbstractStateEvent from '@/Events/Received/Plugin/AbstractStateEvent';
+import { ControllerType } from '@/Events/Received/Plugin/ControllerType';
+import { BaseVisibilityType } from '@/StreamdeckTypes/Sent/BaseVisibilityType';
+
+export default abstract class AbstractVisibilityEvent extends AbstractStateEvent {
+  protected readonly eventPayload!: BaseVisibilityType;
+
+  public get controller(): ControllerType {
+    return this.eventPayload.payload.controller;
+  }
+}

--- a/src/Events/Received/Plugin/AbstractVisibilityEvent.ts
+++ b/src/Events/Received/Plugin/AbstractVisibilityEvent.ts
@@ -5,7 +5,15 @@ import { BaseVisibilityType } from '@/StreamdeckTypes/Sent/BaseVisibilityType';
 export default abstract class AbstractVisibilityEvent extends AbstractStateEvent {
   protected readonly eventPayload!: BaseVisibilityType;
 
+  /**
+   * Return the controller type associated with this specific event. Used to determine if a specific event is on a
+   * standard button or a rotary dial. This will not change during an action's lifecycle.
+   * For plugins running on Stream Deck software v5, this will always return "Keypad".
+   * @returns {ControllerType} The controller type (either "Keypad" or "Encoder") of this action's event.
+   */
   public get controller(): ControllerType {
-    return this.eventPayload.payload.controller;
+    // Fallback to Keypad is okay, as this will always be set on v6+, and v5 only supports keypad-driven events.
+    // A v6-aware plugin looking for an encoder while running on v5 will simply receive Keypad and carry on normally.
+    return this.eventPayload.payload.controller ?? ControllerType.Keypad;
   }
 }

--- a/src/Events/Received/Plugin/ControllerType.ts
+++ b/src/Events/Received/Plugin/ControllerType.ts
@@ -1,4 +1,16 @@
 export enum ControllerType {
-  Keypad,
-  Encoder,
+  /**
+   * Represents actions present on "keypad" style buttons within the button matrix of a Stream Deck, or a Corsair
+   * hotkey.
+   */
+  Keypad = 'Keypad',
+
+  /**
+   * Represents actions present on dials or rotary encoders, such as those on the Stream Deck Plus. In addition to
+   * rotary events, these actions have the ability to show feedback (see {@link SetFeedbackEvent}) to display state to
+   * users.
+   *
+   * Only present when using Stream Deck 6.0 or later.
+   */
+  Encoder = 'Encoder',
 }

--- a/src/Events/Received/Plugin/ControllerType.ts
+++ b/src/Events/Received/Plugin/ControllerType.ts
@@ -1,0 +1,4 @@
+export enum ControllerType {
+  Keypad,
+  Encoder,
+}

--- a/src/Events/Received/Plugin/DeviceDidConnectEvent.ts
+++ b/src/Events/Received/Plugin/DeviceDidConnectEvent.ts
@@ -20,8 +20,6 @@ export default class DeviceDidConnectEvent extends AbstractReceivedBaseEvent {
   }
 
   public get typeName(): keyof typeof DeviceType {
-    // ToDo: redeclare this as just string? Does it really need to be typed this strictly?
-
     switch (this.eventPayload.deviceInfo.type) {
       case DeviceType.StreamDeck:
         return 'StreamDeck';

--- a/src/Events/Received/Plugin/DeviceDidConnectEvent.ts
+++ b/src/Events/Received/Plugin/DeviceDidConnectEvent.ts
@@ -1,7 +1,7 @@
-import {DeviceDidConnectType} from '@/StreamdeckTypes/Sent';
+import { DeviceDidConnectType } from '@/StreamdeckTypes/Sent';
 
 import AbstractReceivedBaseEvent from '../AbstractReceivedBaseEvent';
-import {DeviceType} from './DeviceType';
+import { DeviceType } from './DeviceType';
 
 export default class DeviceDidConnectEvent extends AbstractReceivedBaseEvent {
   public readonly event = 'deviceDidConnect';
@@ -19,7 +19,9 @@ export default class DeviceDidConnectEvent extends AbstractReceivedBaseEvent {
     return this.eventPayload.deviceInfo.type;
   }
 
-  public get typeName(): 'StreamDeck' | 'StreamDeckMini' | 'StreamDeckXL' | 'StreamDeckMobile' | 'CorsairGKeys' | 'StreamDeckPlus' {
+  public get typeName(): keyof typeof DeviceType {
+    // ToDo: redeclare this as just string? Does it really need to be typed this strictly?
+
     switch (this.eventPayload.deviceInfo.type) {
       case DeviceType.StreamDeck:
         return 'StreamDeck';
@@ -31,8 +33,12 @@ export default class DeviceDidConnectEvent extends AbstractReceivedBaseEvent {
         return 'StreamDeckMobile';
       case DeviceType.CorsairGKeys:
         return 'CorsairGKeys';
+      case DeviceType.StreamDeckPedal:
+        return 'StreamDeckPedal';
+      case DeviceType.CorsairVoyager:
+        return 'CorsairVoyager';
       case DeviceType.StreamDeckPlus:
-        return 'StreamDeckPlus'
+        return 'StreamDeckPlus';
       /* istanbul ignore next - just a typecheck - unreachable code, based on the payload validation */
       default:
         // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/Events/Received/Plugin/DeviceDidConnectEvent.ts
+++ b/src/Events/Received/Plugin/DeviceDidConnectEvent.ts
@@ -1,7 +1,7 @@
-import { DeviceDidConnectType } from '@/StreamdeckTypes/Sent';
+import {DeviceDidConnectType} from '@/StreamdeckTypes/Sent';
 
 import AbstractReceivedBaseEvent from '../AbstractReceivedBaseEvent';
-import { DeviceType } from './DeviceType';
+import {DeviceType} from './DeviceType';
 
 export default class DeviceDidConnectEvent extends AbstractReceivedBaseEvent {
   public readonly event = 'deviceDidConnect';
@@ -19,7 +19,7 @@ export default class DeviceDidConnectEvent extends AbstractReceivedBaseEvent {
     return this.eventPayload.deviceInfo.type;
   }
 
-  public get typeName(): 'StreamDeck' | 'StreamDeckMini' | 'StreamDeckXL' | 'StreamDeckMobile' | 'CorsairGKeys' {
+  public get typeName(): 'StreamDeck' | 'StreamDeckMini' | 'StreamDeckXL' | 'StreamDeckMobile' | 'CorsairGKeys' | 'StreamDeckPlus' {
     switch (this.eventPayload.deviceInfo.type) {
       case DeviceType.StreamDeck:
         return 'StreamDeck';
@@ -31,6 +31,8 @@ export default class DeviceDidConnectEvent extends AbstractReceivedBaseEvent {
         return 'StreamDeckMobile';
       case DeviceType.CorsairGKeys:
         return 'CorsairGKeys';
+      case DeviceType.StreamDeckPlus:
+        return 'StreamDeckPlus'
       /* istanbul ignore next - just a typecheck - unreachable code, based on the payload validation */
       default:
         // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/Events/Received/Plugin/DeviceType.ts
+++ b/src/Events/Received/Plugin/DeviceType.ts
@@ -4,4 +4,5 @@ export enum DeviceType {
   StreamDeckXL,
   StreamDeckMobile,
   CorsairGKeys,
+  StreamDeckPlus = 7
 }

--- a/src/Events/Received/Plugin/DeviceType.ts
+++ b/src/Events/Received/Plugin/DeviceType.ts
@@ -4,5 +4,7 @@ export enum DeviceType {
   StreamDeckXL,
   StreamDeckMobile,
   CorsairGKeys,
-  StreamDeckPlus = 7
+  StreamDeckPedal,
+  CorsairVoyager,
+  StreamDeckPlus,
 }

--- a/src/Events/Received/Plugin/Dial/AbstractDialEvent.ts
+++ b/src/Events/Received/Plugin/Dial/AbstractDialEvent.ts
@@ -1,0 +1,22 @@
+import AbstractReceivedExtendedEvent from "@/Events/Received/AbstractReceivedExtendedEvent";
+import {BaseDialType} from "@/StreamdeckTypes/Sent/Dial/BaseDialType";
+
+export default abstract class AbstractDialEvent extends AbstractReceivedExtendedEvent {
+  declare protected readonly eventPayload: BaseDialType;
+
+  public get settings(): unknown {
+    return this.eventPayload.payload.settings;
+  }
+
+  public get controller(): string {
+    return this.eventPayload.payload.controller;
+  }
+
+  public get row(): number | undefined {
+    return this.eventPayload.payload.coordinates?.row;
+  }
+
+  public get column(): number | undefined {
+    return this.eventPayload.payload.coordinates?.column;
+  }
+}

--- a/src/Events/Received/Plugin/Dial/AbstractDialEvent.ts
+++ b/src/Events/Received/Plugin/Dial/AbstractDialEvent.ts
@@ -1,8 +1,8 @@
-import AbstractReceivedExtendedEvent from "@/Events/Received/AbstractReceivedExtendedEvent";
-import {BaseDialType} from "@/StreamdeckTypes/Sent/Dial/BaseDialType";
+import AbstractReceivedExtendedEvent from '@/Events/Received/AbstractReceivedExtendedEvent';
+import { BaseDialType } from '@/StreamdeckTypes/Sent/Dial/BaseDialType';
 
 export default abstract class AbstractDialEvent extends AbstractReceivedExtendedEvent {
-  declare protected readonly eventPayload: BaseDialType;
+  protected declare readonly eventPayload: BaseDialType;
 
   public get settings(): unknown {
     return this.eventPayload.payload.settings;

--- a/src/Events/Received/Plugin/Dial/AbstractDialEvent.ts
+++ b/src/Events/Received/Plugin/Dial/AbstractDialEvent.ts
@@ -9,6 +9,10 @@ export default abstract class AbstractDialEvent extends AbstractReceivedExtended
     return this.eventPayload.payload.settings;
   }
 
+  /**
+   * Get the Controller that fired this event.
+   * @returns {ControllerType} Will always return `Encoder`.
+   */
   public get controller(): ControllerType {
     return this.eventPayload.payload.controller;
   }

--- a/src/Events/Received/Plugin/Dial/AbstractDialEvent.ts
+++ b/src/Events/Received/Plugin/Dial/AbstractDialEvent.ts
@@ -1,4 +1,5 @@
 import AbstractReceivedExtendedEvent from '@/Events/Received/AbstractReceivedExtendedEvent';
+import { ControllerType } from '@/Events/Received/Plugin/ControllerType';
 import { BaseDialType } from '@/StreamdeckTypes/Sent/Dial/BaseDialType';
 
 export default abstract class AbstractDialEvent extends AbstractReceivedExtendedEvent {
@@ -8,7 +9,7 @@ export default abstract class AbstractDialEvent extends AbstractReceivedExtended
     return this.eventPayload.payload.settings;
   }
 
-  public get controller(): string {
+  public get controller(): ControllerType {
     return this.eventPayload.payload.controller;
   }
 

--- a/src/Events/Received/Plugin/Dial/AbstractEncoderEvent.ts
+++ b/src/Events/Received/Plugin/Dial/AbstractEncoderEvent.ts
@@ -1,10 +1,10 @@
-import AbstractDialEvent from "@/Events/Received/Plugin/Dial/AbstractDialEvent";
-import {BaseEncoderType} from "@/StreamdeckTypes/Sent/Dial/BaseEncoderType";
+import AbstractDialEvent from '@/Events/Received/Plugin/Dial/AbstractDialEvent';
+import { BaseEncoderType } from '@/StreamdeckTypes/Sent/Dial/BaseEncoderType';
 
 export default abstract class AbstractEncoderEvent extends AbstractDialEvent {
-  declare protected readonly eventPayload: BaseEncoderType;
+  protected declare readonly eventPayload: BaseEncoderType;
 
-  public get pressed(): Boolean {
-    return this.eventPayload.payload.pressed
+  public get pressed(): boolean {
+    return this.eventPayload.payload.pressed;
   }
 }

--- a/src/Events/Received/Plugin/Dial/AbstractEncoderEvent.ts
+++ b/src/Events/Received/Plugin/Dial/AbstractEncoderEvent.ts
@@ -1,0 +1,10 @@
+import AbstractDialEvent from "@/Events/Received/Plugin/Dial/AbstractDialEvent";
+import {BaseEncoderType} from "@/StreamdeckTypes/Sent/Dial/BaseEncoderType";
+
+export default abstract class AbstractEncoderEvent extends AbstractDialEvent {
+  declare protected readonly eventPayload: BaseEncoderType;
+
+  public get pressed(): Boolean {
+    return this.eventPayload.payload.pressed
+  }
+}

--- a/src/Events/Received/Plugin/Dial/AbstractEncoderEvent.ts
+++ b/src/Events/Received/Plugin/Dial/AbstractEncoderEvent.ts
@@ -4,6 +4,10 @@ import { BaseEncoderType } from '@/StreamdeckTypes/Sent/Dial/BaseEncoderType';
 export default abstract class AbstractEncoderEvent extends AbstractDialEvent {
   protected declare readonly eventPayload: BaseEncoderType;
 
+  /**
+   * Checks if a dial was pressed in while this event happened.
+   * @returns {boolean} Returns true if the dial was pressed in, false otherwise.
+   */
   public get pressed(): boolean {
     return this.eventPayload.payload.pressed;
   }

--- a/src/Events/Received/Plugin/Dial/DialPressEvent.ts
+++ b/src/Events/Received/Plugin/Dial/DialPressEvent.ts
@@ -1,0 +1,10 @@
+import AbstractEncoderEvent from "@/Events/Received/Plugin/Dial/AbstractEncoderEvent";
+import {DialPressEventType} from "@/StreamdeckTypes/Sent/Dial";
+
+export default class DialPressEvent extends AbstractEncoderEvent {
+  public readonly event = 'dialPress';
+
+  protected get validationType(): typeof DialPressEventType {
+    return DialPressEventType;
+  }
+}

--- a/src/Events/Received/Plugin/Dial/DialPressEvent.ts
+++ b/src/Events/Received/Plugin/Dial/DialPressEvent.ts
@@ -1,6 +1,11 @@
 import AbstractEncoderEvent from '@/Events/Received/Plugin/Dial/AbstractEncoderEvent';
 import { DialPressEventType } from '@/StreamdeckTypes/Sent/Dial';
 
+/**
+ * An event fired when the user presses or releases a dial on their Stream Deck.
+ *
+ * In order to determine if this was a press or release event, check the result of {@linkcode pressed}.
+ */
 export default class DialPressEvent extends AbstractEncoderEvent {
   public readonly event = 'dialPress';
 

--- a/src/Events/Received/Plugin/Dial/DialPressEvent.ts
+++ b/src/Events/Received/Plugin/Dial/DialPressEvent.ts
@@ -1,5 +1,5 @@
-import AbstractEncoderEvent from "@/Events/Received/Plugin/Dial/AbstractEncoderEvent";
-import {DialPressEventType} from "@/StreamdeckTypes/Sent/Dial";
+import AbstractEncoderEvent from '@/Events/Received/Plugin/Dial/AbstractEncoderEvent';
+import { DialPressEventType } from '@/StreamdeckTypes/Sent/Dial';
 
 export default class DialPressEvent extends AbstractEncoderEvent {
   public readonly event = 'dialPress';

--- a/src/Events/Received/Plugin/Dial/DialRotateEvent.ts
+++ b/src/Events/Received/Plugin/Dial/DialRotateEvent.ts
@@ -1,0 +1,15 @@
+import AbstractEncoderEvent from "@/Events/Received/Plugin/Dial/AbstractEncoderEvent";
+import {DialRotateEventType} from "@/StreamdeckTypes/Sent/Dial";
+
+export default class DialRotateEvent extends AbstractEncoderEvent {
+  public readonly event = 'dialRotate';
+  declare protected readonly eventPayload: DialRotateEventType;
+
+  protected get validationType(): typeof DialRotateEventType {
+    return DialRotateEventType;
+  }
+
+  public get ticks(): number {
+    return this.eventPayload.payload.ticks;
+  }
+}

--- a/src/Events/Received/Plugin/Dial/DialRotateEvent.ts
+++ b/src/Events/Received/Plugin/Dial/DialRotateEvent.ts
@@ -1,6 +1,14 @@
 import AbstractEncoderEvent from '@/Events/Received/Plugin/Dial/AbstractEncoderEvent';
 import { DialRotateEventType } from '@/StreamdeckTypes/Sent/Dial';
 
+/**
+ * An event fired when the user rotates a dial on their Stream Deck.
+ *
+ * The Stream Deck software may elect to compress multiple incremental steps ("ticks") into a single event, especially
+ * if the user is turning a dial very quickly. Consumers of this event should check the {@link ticks} value to
+ * determine exactly how far the user rotated the dial. A dial may optionally be held during any given rotation, which
+ * will be reflected accordingly.
+ */
 export default class DialRotateEvent extends AbstractEncoderEvent {
   public readonly event = 'dialRotate';
   protected declare readonly eventPayload: DialRotateEventType;
@@ -9,6 +17,11 @@ export default class DialRotateEvent extends AbstractEncoderEvent {
     return DialRotateEventType;
   }
 
+  /**
+   * Get the number of "ticks" for a given rotation event. Clockwise rotations will result in a positive value, while
+   * counter-clockwise rotations will result in a negative one.
+   * @returns The number of ticks that a dial was rotated.
+   */
   public get ticks(): number {
     return this.eventPayload.payload.ticks;
   }

--- a/src/Events/Received/Plugin/Dial/DialRotateEvent.ts
+++ b/src/Events/Received/Plugin/Dial/DialRotateEvent.ts
@@ -1,9 +1,9 @@
-import AbstractEncoderEvent from "@/Events/Received/Plugin/Dial/AbstractEncoderEvent";
-import {DialRotateEventType} from "@/StreamdeckTypes/Sent/Dial";
+import AbstractEncoderEvent from '@/Events/Received/Plugin/Dial/AbstractEncoderEvent';
+import { DialRotateEventType } from '@/StreamdeckTypes/Sent/Dial';
 
 export default class DialRotateEvent extends AbstractEncoderEvent {
   public readonly event = 'dialRotate';
-  declare protected readonly eventPayload: DialRotateEventType;
+  protected declare readonly eventPayload: DialRotateEventType;
 
   protected get validationType(): typeof DialRotateEventType {
     return DialRotateEventType;

--- a/src/Events/Received/Plugin/Dial/TouchTapEvent.ts
+++ b/src/Events/Received/Plugin/Dial/TouchTapEvent.ts
@@ -13,7 +13,7 @@ export default class TouchTapEvent extends AbstractDialEvent {
     return this.eventPayload.payload.hold;
   }
 
-  public get tapPos(): Array<number> {
+  public get tapPos(): [number, number] {
     return this.eventPayload.payload.tapPos;
   }
 }

--- a/src/Events/Received/Plugin/Dial/TouchTapEvent.ts
+++ b/src/Events/Received/Plugin/Dial/TouchTapEvent.ts
@@ -1,6 +1,13 @@
 import AbstractDialEvent from '@/Events/Received/Plugin/Dial/AbstractDialEvent';
 import { TouchTapEventType } from '@/StreamdeckTypes/Sent/Dial/TouchTapEventType';
 
+/**
+ * An event fired when the user touches the screen on a specific dial action.
+ *
+ * This event fires immediately after the user has removed their finger from the screen in a quick tap-and-release, or
+ * after holding their finger on the screen for approximately 500 milliseconds. No event is fired upon the user removing
+ * their finger from the screen in a hold, nor for holds that don't reach the dwell time.
+ */
 export default class TouchTapEvent extends AbstractDialEvent {
   public readonly event = 'touchTap';
   protected declare readonly eventPayload: TouchTapEventType;
@@ -9,10 +16,19 @@ export default class TouchTapEvent extends AbstractDialEvent {
     return TouchTapEventType;
   }
 
+  /**
+   * Check if the user held the touch screen for approximately 500 milliseconds.
+   * @returns {boolean} Returns true if this touch event was a hold, false otherwise.
+   */
   public get hold(): boolean {
     return this.eventPayload.payload.hold;
   }
 
+  /**
+   * Get the precise position of the touch screen tap event. The `[0, 0]` coordinate matches the top left of the
+   * dial's display, while `[200, 100]` represents the bottom right.
+   * @returns Returns a tuple in form [X, Y].
+   */
   public get tapPos(): [number, number] {
     return this.eventPayload.payload.tapPos;
   }

--- a/src/Events/Received/Plugin/Dial/TouchTapEvent.ts
+++ b/src/Events/Received/Plugin/Dial/TouchTapEvent.ts
@@ -1,0 +1,19 @@
+import {TouchTapEventType} from "@/StreamdeckTypes/Sent/Dial/TouchTapEventType";
+import AbstractDialEvent from "@/Events/Received/Plugin/Dial/AbstractDialEvent";
+
+export default class TouchTapEvent extends AbstractDialEvent {
+  public readonly event = 'touchTap';
+  declare protected readonly eventPayload: TouchTapEventType;
+
+  protected get validationType(): typeof TouchTapEventType {
+    return TouchTapEventType;
+  }
+
+  public get hold(): Boolean {
+    return this.eventPayload.payload.hold;
+  }
+
+  public get tapPos(): Array<Number> {
+    return this.eventPayload.payload.tapPos;
+  }
+}

--- a/src/Events/Received/Plugin/Dial/TouchTapEvent.ts
+++ b/src/Events/Received/Plugin/Dial/TouchTapEvent.ts
@@ -1,19 +1,19 @@
-import {TouchTapEventType} from "@/StreamdeckTypes/Sent/Dial/TouchTapEventType";
-import AbstractDialEvent from "@/Events/Received/Plugin/Dial/AbstractDialEvent";
+import AbstractDialEvent from '@/Events/Received/Plugin/Dial/AbstractDialEvent';
+import { TouchTapEventType } from '@/StreamdeckTypes/Sent/Dial/TouchTapEventType';
 
 export default class TouchTapEvent extends AbstractDialEvent {
   public readonly event = 'touchTap';
-  declare protected readonly eventPayload: TouchTapEventType;
+  protected declare readonly eventPayload: TouchTapEventType;
 
   protected get validationType(): typeof TouchTapEventType {
     return TouchTapEventType;
   }
 
-  public get hold(): Boolean {
+  public get hold(): boolean {
     return this.eventPayload.payload.hold;
   }
 
-  public get tapPos(): Array<Number> {
+  public get tapPos(): Array<number> {
     return this.eventPayload.payload.tapPos;
   }
 }

--- a/src/Events/Received/Plugin/Dial/index.ts
+++ b/src/Events/Received/Plugin/Dial/index.ts
@@ -1,0 +1,3 @@
+export { default as DialPressEvent } from './DialPressEvent';
+export { default as DialRotateEvent } from './DialRotateEvent';
+export { default as TouchTapEvent } from './TouchTapEvent';

--- a/src/Events/Received/Plugin/ReceivedPluginEventTypes.ts
+++ b/src/Events/Received/Plugin/ReceivedPluginEventTypes.ts
@@ -14,11 +14,7 @@ import {
   WillAppearEvent,
   WillDisappearEvent,
 } from '@/Events/Received/Plugin';
-
-import {
-  DialPressEvent,
-  DialRotateEvent, TouchTapEvent
-} from "@/Events/Received/Plugin/Dial";
+import { DialPressEvent, DialRotateEvent, TouchTapEvent } from '@/Events/Received/Plugin/Dial';
 
 export type ReceivedPluginEventTypes =
   | ReceivedEventTypes

--- a/src/Events/Received/Plugin/ReceivedPluginEventTypes.ts
+++ b/src/Events/Received/Plugin/ReceivedPluginEventTypes.ts
@@ -15,12 +15,19 @@ import {
   WillDisappearEvent,
 } from '@/Events/Received/Plugin';
 
+import {
+  DialPressEvent,
+  DialRotateEvent, TouchTapEvent
+} from "@/Events/Received/Plugin/Dial";
+
 export type ReceivedPluginEventTypes =
   | ReceivedEventTypes
   | ApplicationDidLaunchEvent
   | ApplicationDidTerminateEvent
   | DeviceDidConnectEvent
   | DeviceDidDisconnectEvent
+  | DialPressEvent
+  | DialRotateEvent
   | KeyDownEvent
   | KeyUpEvent
   | PropertyInspectorDidAppearEvent
@@ -28,5 +35,6 @@ export type ReceivedPluginEventTypes =
   | SendToPluginEvent
   | SystemDidWakeUpEvent
   | TitleParametersDidChangeEvent
+  | TouchTapEvent
   | WillAppearEvent
   | WillDisappearEvent;

--- a/src/Events/Received/Plugin/WillAppearEvent.ts
+++ b/src/Events/Received/Plugin/WillAppearEvent.ts
@@ -1,8 +1,7 @@
+import AbstractVisibilityEvent from '@/Events/Received/Plugin/AbstractVisibilityEvent';
 import { WillAppearType } from '@/StreamdeckTypes/Sent';
 
-import AbstractStateEvent from './AbstractStateEvent';
-
-export default class WillAppearEvent extends AbstractStateEvent {
+export default class WillAppearEvent extends AbstractVisibilityEvent {
   public readonly event = 'willAppear';
 
   protected get validationType(): typeof WillAppearType {

--- a/src/Events/Received/Plugin/WillDisappearEvent.ts
+++ b/src/Events/Received/Plugin/WillDisappearEvent.ts
@@ -1,8 +1,7 @@
+import AbstractVisibilityEvent from '@/Events/Received/Plugin/AbstractVisibilityEvent';
 import { WillDisappearType } from '@/StreamdeckTypes/Sent';
 
-import AbstractStateEvent from './AbstractStateEvent';
-
-export default class WillDisappearEvent extends AbstractStateEvent {
+export default class WillDisappearEvent extends AbstractVisibilityEvent {
   public readonly event = 'willDisappear';
 
   protected get validationType(): typeof WillDisappearType {

--- a/src/Events/Received/Plugin/index.ts
+++ b/src/Events/Received/Plugin/index.ts
@@ -3,6 +3,7 @@ export { default as ApplicationDidTerminateEvent } from './ApplicationDidTermina
 export { default as DeviceDidConnectEvent } from './DeviceDidConnectEvent';
 export { default as DeviceDidDisconnectEvent } from './DeviceDidDisconnectEvent';
 export { DeviceType } from './DeviceType';
+export { DialPressEvent, DialRotateEvent, TouchTapEvent } from './Dial';
 export { default as KeyDownEvent } from './KeyDownEvent';
 export { default as KeyUpEvent } from './KeyUpEvent';
 export { default as PropertyInspectorDidAppearEvent } from './PropertyInspectorDidAppearEvent';

--- a/src/Events/Sent/Plugin/SetFeedbackEvent.ts
+++ b/src/Events/Sent/Plugin/SetFeedbackEvent.ts
@@ -1,10 +1,11 @@
-import AbstractSentSetterEvent from "@/Events/Sent/AbstractSentSetterEvent";
+import AbstractSentSetterEvent from '@/Events/Sent/AbstractSentSetterEvent';
+import { LayoutFeedback } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback';
 
 export default class SetFeedbackEvent extends AbstractSentSetterEvent {
   public readonly event = 'setFeedback';
-  public readonly payload: unknown;
+  public readonly payload: LayoutFeedback;
 
-  constructor(payload: unknown, context: string) {
+  constructor(payload: LayoutFeedback, context: string) {
     super(context);
     this.payload = payload;
   }

--- a/src/Events/Sent/Plugin/SetFeedbackEvent.ts
+++ b/src/Events/Sent/Plugin/SetFeedbackEvent.ts
@@ -1,0 +1,11 @@
+import AbstractSentSetterEvent from "@/Events/Sent/AbstractSentSetterEvent";
+
+export default class SetFeedbackEvent extends AbstractSentSetterEvent {
+  public readonly event = 'setFeedback';
+  public readonly payload: unknown;
+
+  constructor(payload: unknown, context: string) {
+    super(context);
+    this.payload = payload;
+  }
+}

--- a/src/Events/Sent/Plugin/SetFeedbackEvent.ts
+++ b/src/Events/Sent/Plugin/SetFeedbackEvent.ts
@@ -1,11 +1,11 @@
 import AbstractSentSetterEvent from '@/Events/Sent/AbstractSentSetterEvent';
-import { LayoutFeedback } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback';
+import { GenericLayoutFeedback, LayoutFeedback } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback';
 
 export default class SetFeedbackEvent extends AbstractSentSetterEvent {
   public readonly event = 'setFeedback';
-  public readonly payload: LayoutFeedback;
+  public readonly payload: GenericLayoutFeedback;
 
-  constructor(payload: LayoutFeedback, context: string) {
+  constructor(payload: LayoutFeedback | GenericLayoutFeedback, context: string) {
     super(context);
     this.payload = payload;
   }

--- a/src/Events/Sent/Plugin/SetFeedbackEvent.ts
+++ b/src/Events/Sent/Plugin/SetFeedbackEvent.ts
@@ -1,6 +1,9 @@
 import AbstractSentSetterEvent from '@/Events/Sent/AbstractSentSetterEvent';
 import { GenericLayoutFeedback, LayoutFeedback } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback';
 
+/**
+ * See the documentation in {@link EventsSent#setFeedback} for information about this class.
+ */
 export default class SetFeedbackEvent extends AbstractSentSetterEvent {
   public readonly event = 'setFeedback';
   public readonly payload: GenericLayoutFeedback;

--- a/src/Events/Sent/Plugin/SetFeedbackLayoutEvent.ts
+++ b/src/Events/Sent/Plugin/SetFeedbackLayoutEvent.ts
@@ -1,0 +1,17 @@
+import AbstractSentSetterEvent from "@/Events/Sent/AbstractSentSetterEvent";
+
+export default class SetFeedbackLayoutEvent extends AbstractSentSetterEvent {
+  public readonly event = 'setFeedbackLayout';
+  public readonly layout: string;
+
+  constructor(layout: string, context: string) {
+    super(context);
+    this.layout = layout;
+  }
+
+  protected get payload(): unknown {
+    return {
+      layout: this.layout
+    };
+  }
+}

--- a/src/Events/Sent/Plugin/SetFeedbackLayoutEvent.ts
+++ b/src/Events/Sent/Plugin/SetFeedbackLayoutEvent.ts
@@ -3,9 +3,9 @@ import { LayoutFeedbackKey } from '@/StreamdeckTypes/Received/Feedback/LayoutFee
 
 export default class SetFeedbackLayoutEvent extends AbstractSentSetterEvent {
   public readonly event = 'setFeedbackLayout';
-  public readonly layout: LayoutFeedbackKey;
+  public readonly layout: string;
 
-  constructor(layout: LayoutFeedbackKey, context: string) {
+  constructor(layout: string | LayoutFeedbackKey, context: string) {
     super(context);
     this.layout = layout;
   }

--- a/src/Events/Sent/Plugin/SetFeedbackLayoutEvent.ts
+++ b/src/Events/Sent/Plugin/SetFeedbackLayoutEvent.ts
@@ -1,6 +1,9 @@
 import AbstractSentSetterEvent from '@/Events/Sent/AbstractSentSetterEvent';
 import { LayoutFeedbackKey } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback';
 
+/**
+ * See the documentation in {@link EventsSent#setFeedbackLayout} for information about this class.
+ */
 export default class SetFeedbackLayoutEvent extends AbstractSentSetterEvent {
   public readonly event = 'setFeedbackLayout';
   public readonly layout: string;

--- a/src/Events/Sent/Plugin/SetFeedbackLayoutEvent.ts
+++ b/src/Events/Sent/Plugin/SetFeedbackLayoutEvent.ts
@@ -1,17 +1,18 @@
-import AbstractSentSetterEvent from "@/Events/Sent/AbstractSentSetterEvent";
+import AbstractSentSetterEvent from '@/Events/Sent/AbstractSentSetterEvent';
+import { LayoutFeedbackKey } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback';
 
 export default class SetFeedbackLayoutEvent extends AbstractSentSetterEvent {
   public readonly event = 'setFeedbackLayout';
   public readonly layout: string;
 
-  constructor(layout: string, context: string) {
+  constructor(layout: LayoutFeedbackKey | string, context: string) {
     super(context);
     this.layout = layout;
   }
 
   protected get payload(): unknown {
     return {
-      layout: this.layout
+      layout: this.layout,
     };
   }
 }

--- a/src/Events/Sent/Plugin/SetFeedbackLayoutEvent.ts
+++ b/src/Events/Sent/Plugin/SetFeedbackLayoutEvent.ts
@@ -3,9 +3,9 @@ import { LayoutFeedbackKey } from '@/StreamdeckTypes/Received/Feedback/LayoutFee
 
 export default class SetFeedbackLayoutEvent extends AbstractSentSetterEvent {
   public readonly event = 'setFeedbackLayout';
-  public readonly layout: string;
+  public readonly layout: LayoutFeedbackKey;
 
-  constructor(layout: LayoutFeedbackKey | string, context: string) {
+  constructor(layout: LayoutFeedbackKey, context: string) {
     super(context);
     this.layout = layout;
   }

--- a/src/Events/Sent/Plugin/index.ts
+++ b/src/Events/Sent/Plugin/index.ts
@@ -1,4 +1,6 @@
 export { default as SendToPropertyInspectorEvent } from './SendToPropertyInspectorEvent';
+export { default as SetFeedbackEvent } from './SetFeedbackEvent';
+export { default as SetFeedbackLayoutEvent} from './SetFeedbackLayoutEvent';
 export { default as SetImageEvent } from './SetImageEvent';
 export { default as SetTitleEvent } from './SetTitleEvent';
 export { TargetEnum } from './TargetEnum';

--- a/src/Events/Sent/Plugin/index.ts
+++ b/src/Events/Sent/Plugin/index.ts
@@ -1,6 +1,6 @@
 export { default as SendToPropertyInspectorEvent } from './SendToPropertyInspectorEvent';
 export { default as SetFeedbackEvent } from './SetFeedbackEvent';
-export { default as SetFeedbackLayoutEvent} from './SetFeedbackLayoutEvent';
+export { default as SetFeedbackLayoutEvent } from './SetFeedbackLayoutEvent';
 export { default as SetImageEvent } from './SetImageEvent';
 export { default as SetTitleEvent } from './SetTitleEvent';
 export { TargetEnum } from './TargetEnum';

--- a/src/Events/Streamdeck/Received/EventFactory.ts
+++ b/src/Events/Streamdeck/Received/EventFactory.ts
@@ -8,6 +8,8 @@ import {
   RegisterEvent,
   SendToPluginEvent,
   SendToPropertyInspectorEvent,
+  SetFeedbackEvent,
+  SetFeedbackLayoutEvent,
   SetGlobalSettingsEvent,
   SetImageEvent,
   SetSettingsEvent,
@@ -54,6 +56,10 @@ export default class EventFactory {
         return new SendToPluginEvent(payload);
       case 'sendToPropertyInspector':
         return new SendToPropertyInspectorEvent(payload);
+      case 'setFeedback':
+        return new SetFeedbackEvent(payload);
+      case 'setFeedbackLayout':
+        return new SetFeedbackLayoutEvent(payload);
       case 'setGlobalSettings':
         return new SetGlobalSettingsEvent(payload);
       case 'setImage':

--- a/src/Events/Streamdeck/Received/ReceivedEventTypes.ts
+++ b/src/Events/Streamdeck/Received/ReceivedEventTypes.ts
@@ -6,6 +6,8 @@ import {
   RegisterEvent,
   SendToPluginEvent,
   SendToPropertyInspectorEvent,
+  SetFeedbackEvent,
+  SetFeedbackLayoutEvent,
   SetGlobalSettingsEvent,
   SetImageEvent,
   SetSettingsEvent,
@@ -24,6 +26,8 @@ export type ReceivedEventTypes =
   | RegisterEvent
   | SendToPluginEvent
   | SendToPropertyInspectorEvent
+  | SetFeedbackEvent
+  | SetFeedbackLayoutEvent
   | SetGlobalSettingsEvent
   | SetImageEvent
   | SetSettingsEvent

--- a/src/Events/Streamdeck/Received/SetFeedbackEvent.ts
+++ b/src/Events/Streamdeck/Received/SetFeedbackEvent.ts
@@ -1,12 +1,12 @@
 import AbstractReceivedContextEvent from '@/Events/Received/AbstractReceivedContextEvent';
-import { LayoutFeedback } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback';
+import { GenericLayoutFeedback } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback';
 import { SetFeedbackType } from '@/StreamdeckTypes/Received/SetFeedbackType';
 
 export default class SetFeedbackEvent extends AbstractReceivedContextEvent {
   public readonly event = 'setFeedback';
   protected readonly eventPayload!: SetFeedbackType;
 
-  public get payload(): LayoutFeedback {
+  public get payload(): GenericLayoutFeedback {
     return this.eventPayload.payload;
   }
 

--- a/src/Events/Streamdeck/Received/SetFeedbackEvent.ts
+++ b/src/Events/Streamdeck/Received/SetFeedbackEvent.ts
@@ -1,11 +1,12 @@
-import AbstractReceivedContextEvent from "@/Events/Received/AbstractReceivedContextEvent";
-import {SetFeedbackType} from "@/StreamdeckTypes/Received/SetFeedbackType";
+import AbstractReceivedContextEvent from '@/Events/Received/AbstractReceivedContextEvent';
+import { LayoutFeedback } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback';
+import { SetFeedbackType } from '@/StreamdeckTypes/Received/SetFeedbackType';
 
 export default class SetFeedbackEvent extends AbstractReceivedContextEvent {
   public readonly event = 'setFeedback';
   protected readonly eventPayload!: SetFeedbackType;
 
-  public get payload(): unknown {
+  public get payload(): LayoutFeedback {
     return this.eventPayload.payload;
   }
 

--- a/src/Events/Streamdeck/Received/SetFeedbackEvent.ts
+++ b/src/Events/Streamdeck/Received/SetFeedbackEvent.ts
@@ -1,0 +1,15 @@
+import AbstractReceivedContextEvent from "@/Events/Received/AbstractReceivedContextEvent";
+import {SetFeedbackType} from "@/StreamdeckTypes/Received/SetFeedbackType";
+
+export default class SetFeedbackEvent extends AbstractReceivedContextEvent {
+  public readonly event = 'setFeedback';
+  protected readonly eventPayload!: SetFeedbackType;
+
+  public get payload(): unknown {
+    return this.eventPayload.payload;
+  }
+
+  protected get validationType(): typeof SetFeedbackType {
+    return SetFeedbackType;
+  }
+}

--- a/src/Events/Streamdeck/Received/SetFeedbackLayoutEvent.ts
+++ b/src/Events/Streamdeck/Received/SetFeedbackLayoutEvent.ts
@@ -1,12 +1,11 @@
 import AbstractReceivedContextEvent from '@/Events/Received/AbstractReceivedContextEvent';
-import { LayoutFeedbackKey } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback';
 import { SetFeedbackLayoutType } from '@/StreamdeckTypes/Received/SetFeedbackLayoutType';
 
 export default class SetFeedbackLayoutEvent extends AbstractReceivedContextEvent {
   public readonly event = 'setFeedbackLayout';
   protected readonly eventPayload!: SetFeedbackLayoutType;
 
-  public get layout(): LayoutFeedbackKey | string {
+  public get layout(): string {
     return this.eventPayload.payload.layout;
   }
 

--- a/src/Events/Streamdeck/Received/SetFeedbackLayoutEvent.ts
+++ b/src/Events/Streamdeck/Received/SetFeedbackLayoutEvent.ts
@@ -1,0 +1,15 @@
+import AbstractReceivedContextEvent from "@/Events/Received/AbstractReceivedContextEvent";
+import {SetFeedbackLayoutType} from "@/StreamdeckTypes/Received/SetFeedbackLayoutType";
+
+export default class SetFeedbackLayoutEvent extends AbstractReceivedContextEvent {
+  public readonly event = 'setFeedbackLayout';
+  protected readonly eventPayload!: SetFeedbackLayoutType;
+
+  public get layout(): string {
+    return this.eventPayload.payload.layout;
+  }
+
+  protected get validationType(): typeof SetFeedbackLayoutType {
+    return SetFeedbackLayoutType;
+  }
+}

--- a/src/Events/Streamdeck/Received/SetFeedbackLayoutEvent.ts
+++ b/src/Events/Streamdeck/Received/SetFeedbackLayoutEvent.ts
@@ -1,12 +1,11 @@
 import AbstractReceivedContextEvent from '@/Events/Received/AbstractReceivedContextEvent';
-import { LayoutFeedbackKey } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback';
 import { SetFeedbackLayoutType } from '@/StreamdeckTypes/Received/SetFeedbackLayoutType';
 
 export default class SetFeedbackLayoutEvent extends AbstractReceivedContextEvent {
   public readonly event = 'setFeedbackLayout';
   protected readonly eventPayload!: SetFeedbackLayoutType;
 
-  public get layout(): LayoutFeedbackKey {
+  public get layout(): string {
     return this.eventPayload.payload.layout;
   }
 

--- a/src/Events/Streamdeck/Received/SetFeedbackLayoutEvent.ts
+++ b/src/Events/Streamdeck/Received/SetFeedbackLayoutEvent.ts
@@ -1,11 +1,12 @@
 import AbstractReceivedContextEvent from '@/Events/Received/AbstractReceivedContextEvent';
+import { LayoutFeedbackKey } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback';
 import { SetFeedbackLayoutType } from '@/StreamdeckTypes/Received/SetFeedbackLayoutType';
 
 export default class SetFeedbackLayoutEvent extends AbstractReceivedContextEvent {
   public readonly event = 'setFeedbackLayout';
   protected readonly eventPayload!: SetFeedbackLayoutType;
 
-  public get layout(): string {
+  public get layout(): LayoutFeedbackKey {
     return this.eventPayload.payload.layout;
   }
 

--- a/src/Events/Streamdeck/Received/SetFeedbackLayoutEvent.ts
+++ b/src/Events/Streamdeck/Received/SetFeedbackLayoutEvent.ts
@@ -1,11 +1,12 @@
-import AbstractReceivedContextEvent from "@/Events/Received/AbstractReceivedContextEvent";
-import {SetFeedbackLayoutType} from "@/StreamdeckTypes/Received/SetFeedbackLayoutType";
+import AbstractReceivedContextEvent from '@/Events/Received/AbstractReceivedContextEvent';
+import { LayoutFeedbackKey } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback';
+import { SetFeedbackLayoutType } from '@/StreamdeckTypes/Received/SetFeedbackLayoutType';
 
 export default class SetFeedbackLayoutEvent extends AbstractReceivedContextEvent {
   public readonly event = 'setFeedbackLayout';
   protected readonly eventPayload!: SetFeedbackLayoutType;
 
-  public get layout(): string {
+  public get layout(): LayoutFeedbackKey | string {
     return this.eventPayload.payload.layout;
   }
 

--- a/src/Events/Streamdeck/Received/index.ts
+++ b/src/Events/Streamdeck/Received/index.ts
@@ -6,6 +6,8 @@ export { default as OpenUrlEvent } from './OpenUrlEvent';
 export { default as RegisterEvent } from './RegisterEvent';
 export { default as SendToPluginEvent } from './SendToPluginEvent';
 export { default as SendToPropertyInspectorEvent } from './SendToPropertyInspectorEvent';
+export { default as SetFeedbackEvent } from './SetFeedbackEvent';
+export { default as SetFeedbackLayoutEvent } from './SetFeedbackLayoutEvent';
 export { default as SetGlobalSettingsEvent } from './SetGlobalSettingsEvent';
 export { default as SetImageEvent } from './SetImageEvent';
 export { default as SetSettingsEvent } from './SetSettingsEvent';

--- a/src/Events/Streamdeck/Sent/WillAppearEvent.ts
+++ b/src/Events/Streamdeck/Sent/WillAppearEvent.ts
@@ -1,3 +1,4 @@
+import { ControllerType } from '@/Events/Received/Plugin/ControllerType';
 import { WillAppearType } from '@/StreamdeckTypes/Sent';
 
 export interface WillAppearOptions {
@@ -5,12 +6,14 @@ export interface WillAppearOptions {
   event: string;
   column: number;
   row: number;
+  controller: ControllerType;
   isInMultiAction: boolean;
   settings: unknown;
 }
 
 const WillAppearDefaults: WillAppearOptions = {
   column: 1,
+  controller: ControllerType.Keypad,
   device: 'device',
   event: 'willAppear',
   isInMultiAction: false,
@@ -28,6 +31,7 @@ export default class WillAppearEvent {
       device: options?.device || WillAppearDefaults.device,
       event: WillAppearDefaults.event,
       payload: {
+        controller: options?.controller || WillAppearDefaults.controller,
         coordinates: {
           column: options?.column || WillAppearDefaults.column,
           row: options?.row || WillAppearDefaults.row,

--- a/src/StreamdeckTypes/Received/Feedback/Components/BarFeedbackComponent.ts
+++ b/src/StreamdeckTypes/Received/Feedback/Components/BarFeedbackComponent.ts
@@ -10,6 +10,8 @@ export enum BarComponentSubtype {
   ROUNDED_BAR = 4,
 }
 
+export const BarValueType = Type.Number({ maximum: 100, minimum: 0 });
+
 export const BarFeedbackComponentProperties = {
   ...BaseFeedbackComponentProperties,
 
@@ -20,7 +22,9 @@ export const BarFeedbackComponentProperties = {
   border_w: OptionalNullable(Type.Number({ default: 0, minimum: 0 })),
 
   subtype: OptionalNullable(Type.Enum(BarComponentSubtype, { default: BarComponentSubtype.ROUNDED_BAR })),
-  value: OptionalNullable(Type.Number({ maximum: 100, minimum: 0 })),
+  value: OptionalNullable(BarValueType),
 };
 export const BarFeedbackComponent = Type.Object(BarFeedbackComponentProperties);
 export type BarFeedbackComponent = Static<typeof BarFeedbackComponent>;
+
+export const WrappedBarFeedbackComponent = Type.Union([BarFeedbackComponent, BarValueType]);

--- a/src/StreamdeckTypes/Received/Feedback/Components/BarFeedbackComponent.ts
+++ b/src/StreamdeckTypes/Received/Feedback/Components/BarFeedbackComponent.ts
@@ -1,0 +1,26 @@
+import { Static, Type } from '@sinclair/typebox';
+
+import { BaseFeedbackComponentProperties, OptionalNullable } from './BaseFeedbackComponent';
+
+export enum BarComponentSubtype {
+  SQUARE_BAR = 0,
+  SQUARE_CENTERED_BAR = 1,
+  WEDGE_BAR = 2,
+  DOUBLE_WEDGE_BAR = 3,
+  ROUNDED_BAR = 4,
+}
+
+export const BarFeedbackComponentProperties = {
+  ...BaseFeedbackComponentProperties,
+
+  bar_bg_c: OptionalNullable(Type.String()),
+  bar_border_c: OptionalNullable(Type.String()),
+  bar_fill_c: OptionalNullable(Type.String()),
+
+  border_w: OptionalNullable(Type.Number({ default: 0, minimum: 0 })),
+
+  subtype: OptionalNullable(Type.Enum(BarComponentSubtype, { default: BarComponentSubtype.ROUNDED_BAR })),
+  value: OptionalNullable(Type.Number({ maximum: 100, minimum: 0 })),
+};
+export const BarFeedbackComponent = Type.Object(BarFeedbackComponentProperties);
+export type BarFeedbackComponent = Static<typeof BarFeedbackComponent>;

--- a/src/StreamdeckTypes/Received/Feedback/Components/BaseFeedbackComponent.ts
+++ b/src/StreamdeckTypes/Received/Feedback/Components/BaseFeedbackComponent.ts
@@ -16,14 +16,18 @@ const TransformableFeedbackComponentProperties = {
   // translate: Type.Unknown(),
 };
 
+export const BaseComponentValueType = Type.Union([Type.String(), Type.Number(), Type.Null()]);
+
 export const BaseFeedbackComponentProperties = {
   ...OutlinableFeedbackComponentProperties,
   ...TransformableFeedbackComponentProperties,
 
   background: OptionalNullable(Type.String()),
   enabled: Type.Optional(Type.Boolean()),
-  value: Type.Optional(Type.Union([Type.String(), Type.Number(), Type.Null()])),
+  value: Type.Optional(BaseComponentValueType),
   zOrder: Type.Optional(Type.Number()),
 };
 export const BaseFeedbackComponent = Type.Object(BaseFeedbackComponentProperties);
 export type BaseFeedbackComponent = Static<typeof BaseFeedbackComponent>;
+
+export const WrappedBaseComponent = Type.Union([BaseFeedbackComponent, BaseComponentValueType]);

--- a/src/StreamdeckTypes/Received/Feedback/Components/BaseFeedbackComponent.ts
+++ b/src/StreamdeckTypes/Received/Feedback/Components/BaseFeedbackComponent.ts
@@ -1,0 +1,29 @@
+import { Static, TSchema, Type } from '@sinclair/typebox';
+
+export const Nullable = <T extends TSchema>(type: T) => Type.Union([type, Type.Null()]);
+export const OptionalNullable = <T extends TSchema>(type: T) => Type.Optional(Nullable(type));
+
+const OutlinableFeedbackComponentProperties = {
+  outline_c: OptionalNullable(Type.String()),
+  outline_w: OptionalNullable(Type.Number({ minimum: 0 })),
+  // outline_m: Type.Unknown(),
+};
+
+const TransformableFeedbackComponentProperties = {
+  opacity: OptionalNullable(Type.Number({ default: 1, maximum: 1, minimum: 0 })),
+  rotate: OptionalNullable(Type.Number({ default: 0 })),
+  scale: OptionalNullable(Type.Number({ default: 1 })),
+  // translate: Type.Unknown(),
+};
+
+export const BaseFeedbackComponentProperties = {
+  ...OutlinableFeedbackComponentProperties,
+  ...TransformableFeedbackComponentProperties,
+
+  background: OptionalNullable(Type.String()),
+  enabled: Type.Optional(Type.Boolean()),
+  value: Type.Optional(Type.Union([Type.String(), Type.Number(), Type.Null()])),
+  zOrder: Type.Optional(Type.Number()),
+};
+export const BaseFeedbackComponent = Type.Object(BaseFeedbackComponentProperties);
+export type BaseFeedbackComponent = Static<typeof BaseFeedbackComponent>;

--- a/src/StreamdeckTypes/Received/Feedback/Components/BaseFeedbackComponent.ts
+++ b/src/StreamdeckTypes/Received/Feedback/Components/BaseFeedbackComponent.ts
@@ -6,14 +6,12 @@ export const OptionalNullable = <T extends TSchema>(type: T) => Type.Optional(Nu
 const OutlinableFeedbackComponentProperties = {
   outline_c: OptionalNullable(Type.String()),
   outline_w: OptionalNullable(Type.Number({ minimum: 0 })),
-  // outline_m: Type.Unknown(),
 };
 
 const TransformableFeedbackComponentProperties = {
   opacity: OptionalNullable(Type.Number({ default: 1, maximum: 1, minimum: 0 })),
   rotate: OptionalNullable(Type.Number({ default: 0 })),
   scale: OptionalNullable(Type.Number({ default: 1 })),
-  // translate: Type.Unknown(),
 };
 
 export const BaseComponentValueType = Type.Union([Type.String(), Type.Number(), Type.Null()]);

--- a/src/StreamdeckTypes/Received/Feedback/Components/GrooveBarFeedbackComponent.ts
+++ b/src/StreamdeckTypes/Received/Feedback/Components/GrooveBarFeedbackComponent.ts
@@ -1,6 +1,6 @@
 import { Static, Type } from '@sinclair/typebox';
 
-import { BarFeedbackComponentProperties } from './BarFeedbackComponent';
+import { BarFeedbackComponentProperties, BarValueType } from './BarFeedbackComponent';
 import { OptionalNullable } from './BaseFeedbackComponent';
 
 export const GrooveBarFeedbackComponentProperties = {
@@ -10,3 +10,5 @@ export const GrooveBarFeedbackComponentProperties = {
 };
 export const GrooveBarFeedbackComponent = Type.Object(GrooveBarFeedbackComponentProperties);
 export type GrooveBarFeedbackComponent = Static<typeof GrooveBarFeedbackComponent>;
+
+export const WrappedGrooveBarFeedbackComponent = Type.Union([GrooveBarFeedbackComponent, BarValueType]);

--- a/src/StreamdeckTypes/Received/Feedback/Components/GrooveBarFeedbackComponent.ts
+++ b/src/StreamdeckTypes/Received/Feedback/Components/GrooveBarFeedbackComponent.ts
@@ -1,0 +1,12 @@
+import { Static, Type } from '@sinclair/typebox';
+
+import { BarFeedbackComponentProperties } from './BarFeedbackComponent';
+import { OptionalNullable } from './BaseFeedbackComponent';
+
+export const GrooveBarFeedbackComponentProperties = {
+  ...BarFeedbackComponentProperties,
+
+  bar_h: OptionalNullable(Type.Number({ default: 12, minimum: 0 })),
+};
+export const GrooveBarFeedbackComponent = Type.Object(GrooveBarFeedbackComponentProperties);
+export type GrooveBarFeedbackComponent = Static<typeof GrooveBarFeedbackComponent>;

--- a/src/StreamdeckTypes/Received/Feedback/Components/PixmapFeedbackComponent.ts
+++ b/src/StreamdeckTypes/Received/Feedback/Components/PixmapFeedbackComponent.ts
@@ -1,0 +1,11 @@
+import { Static, Type } from '@sinclair/typebox';
+
+import { BaseFeedbackComponentProperties, OptionalNullable } from './BaseFeedbackComponent';
+
+export const PixmapFeedbackComponentProperties = {
+  ...BaseFeedbackComponentProperties,
+
+  value: OptionalNullable(Type.String()),
+};
+export const PixmapFeedbackComponent = Type.Object(PixmapFeedbackComponentProperties);
+export type PixmapFeedbackComponent = Static<typeof PixmapFeedbackComponent>;

--- a/src/StreamdeckTypes/Received/Feedback/Components/PixmapFeedbackComponent.ts
+++ b/src/StreamdeckTypes/Received/Feedback/Components/PixmapFeedbackComponent.ts
@@ -2,10 +2,14 @@ import { Static, Type } from '@sinclair/typebox';
 
 import { BaseFeedbackComponentProperties, OptionalNullable } from './BaseFeedbackComponent';
 
+const ValueType = Type.String();
+
 export const PixmapFeedbackComponentProperties = {
   ...BaseFeedbackComponentProperties,
 
-  value: OptionalNullable(Type.String()),
+  value: OptionalNullable(ValueType),
 };
 export const PixmapFeedbackComponent = Type.Object(PixmapFeedbackComponentProperties);
 export type PixmapFeedbackComponent = Static<typeof PixmapFeedbackComponent>;
+
+export const WrappedPixmapFeedbackComponent = Type.Union([PixmapFeedbackComponent, ValueType]);

--- a/src/StreamdeckTypes/Received/Feedback/Components/TextFeedbackComponent.ts
+++ b/src/StreamdeckTypes/Received/Feedback/Components/TextFeedbackComponent.ts
@@ -1,7 +1,7 @@
 import { Static, Type } from '@sinclair/typebox';
 
 import { FontFamily, FontStyle, TextAlignment } from '../Misc/TextTypes';
-import { BaseFeedbackComponentProperties, OptionalNullable } from './BaseFeedbackComponent';
+import { BaseComponentValueType, BaseFeedbackComponentProperties, OptionalNullable } from './BaseFeedbackComponent';
 
 export const FontProperties = {
   family: Type.Optional(Type.Enum(FontFamily)),
@@ -21,3 +21,5 @@ export const TextFeedbackComponentProperties = {
 };
 export const TextFeedbackComponent = Type.Object(TextFeedbackComponentProperties);
 export type TextFeedbackComponent = Static<typeof TextFeedbackComponent>;
+
+export const WrappedTextFeedbackComponent = Type.Union([TextFeedbackComponent, BaseComponentValueType]);

--- a/src/StreamdeckTypes/Received/Feedback/Components/TextFeedbackComponent.ts
+++ b/src/StreamdeckTypes/Received/Feedback/Components/TextFeedbackComponent.ts
@@ -1,0 +1,23 @@
+import { Static, Type } from '@sinclair/typebox';
+
+import { FontFamily, FontStyle, TextAlignment } from '../Misc/TextTypes';
+import { BaseFeedbackComponentProperties, OptionalNullable } from './BaseFeedbackComponent';
+
+export const FontProperties = {
+  family: Type.Optional(Type.Enum(FontFamily)),
+  size: Type.Optional(Type.Number()),
+  style: Type.Optional(Type.Enum(FontStyle)),
+  weight: Type.Optional(Type.Number()),
+};
+export const FontProperty = Type.Object(FontProperties);
+export type FontProperty = Static<typeof FontProperty>;
+
+export const TextFeedbackComponentProperties = {
+  ...BaseFeedbackComponentProperties,
+
+  alignment: Type.Optional(Type.Enum(TextAlignment)),
+  color: OptionalNullable(Type.String()),
+  font: Type.Optional(FontProperty),
+};
+export const TextFeedbackComponent = Type.Object(TextFeedbackComponentProperties);
+export type TextFeedbackComponent = Static<typeof TextFeedbackComponent>;

--- a/src/StreamdeckTypes/Received/Feedback/Components/index.ts
+++ b/src/StreamdeckTypes/Received/Feedback/Components/index.ts
@@ -1,4 +1,18 @@
+import { BarFeedbackComponent } from './BarFeedbackComponent';
+import { GrooveBarFeedbackComponent } from './GrooveBarFeedbackComponent';
+import { PixmapFeedbackComponent } from './PixmapFeedbackComponent';
+import { TextFeedbackComponent } from './TextFeedbackComponent';
+
 export { BarFeedbackComponent } from './BarFeedbackComponent';
 export { GrooveBarFeedbackComponent } from './GrooveBarFeedbackComponent';
 export { PixmapFeedbackComponent } from './PixmapFeedbackComponent';
 export { TextFeedbackComponent } from './TextFeedbackComponent';
+
+export type AnyComponent =
+  | BarFeedbackComponent
+  | GrooveBarFeedbackComponent
+  | PixmapFeedbackComponent
+  | TextFeedbackComponent
+  | string
+  | number
+  | null;

--- a/src/StreamdeckTypes/Received/Feedback/Components/index.ts
+++ b/src/StreamdeckTypes/Received/Feedback/Components/index.ts
@@ -1,0 +1,4 @@
+export { BarFeedbackComponent } from './BarFeedbackComponent';
+export { GrooveBarFeedbackComponent } from './GrooveBarFeedbackComponent';
+export { PixmapFeedbackComponent } from './PixmapFeedbackComponent';
+export { TextFeedbackComponent } from './TextFeedbackComponent';

--- a/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/BaseLayoutFeedback.ts
+++ b/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/BaseLayoutFeedback.ts
@@ -1,0 +1,12 @@
+import { Type } from '@sinclair/typebox';
+
+import { ValueWrapper } from '@/StreamdeckTypes/Received/Feedback/Misc/ValueWrapper';
+
+export const BaseLayoutFeedbackProperties = {
+  title: Type.Optional(ValueWrapper(Type.Union([Type.String(), Type.Number()]))),
+};
+
+export const IconLayoutFeedbackProperties = {
+  ...BaseLayoutFeedbackProperties,
+  icon: Type.Optional(ValueWrapper(Type.String())),
+};

--- a/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/BaseLayoutFeedback.ts
+++ b/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/BaseLayoutFeedback.ts
@@ -1,5 +1,9 @@
-import { Type } from '@sinclair/typebox';
+import { Static, Type } from '@sinclair/typebox';
 
+import { WrappedBarFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components/BarFeedbackComponent';
+import { WrappedGrooveBarFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components/GrooveBarFeedbackComponent';
+import { WrappedPixmapFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components/PixmapFeedbackComponent';
+import { WrappedTextFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components/TextFeedbackComponent';
 import { ValueWrapper } from '@/StreamdeckTypes/Received/Feedback/Misc/ValueWrapper';
 
 export const BaseLayoutFeedbackProperties = {
@@ -10,3 +14,19 @@ export const IconLayoutFeedbackProperties = {
   ...BaseLayoutFeedbackProperties,
   icon: Type.Optional(ValueWrapper(Type.String())),
 };
+
+// GenericLayoutFeedback derives from IconLayoutFeedback as it's the most complete special case. Because `title` and
+// `icon` behave oddly (only their `value` may be set), we'll use them as the base for the intersection generic type.
+// This isn't great, as not all layouts are guaranteed to have either a title or an icon, but it does provide a safe
+// type interface for those specific keys. The keys themselves are optional and IDEs will already ignore those types
+// for hinting if something more specific is available (or specified) so this is *probably* fine.
+
+export const GenericLayoutFeedback = Type.Object(IconLayoutFeedbackProperties, {
+  additionalProperties: Type.Union([
+    WrappedBarFeedbackComponent,
+    WrappedGrooveBarFeedbackComponent,
+    WrappedPixmapFeedbackComponent,
+    WrappedTextFeedbackComponent,
+  ]),
+});
+export type GenericLayoutFeedback = Static<typeof GenericLayoutFeedback>;

--- a/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutA0Feedback.ts
+++ b/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutA0Feedback.ts
@@ -1,13 +1,13 @@
 import { Static, Type } from '@sinclair/typebox';
 
-import { PixmapFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components';
+import { WrappedPixmapFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components/PixmapFeedbackComponent';
 import { BaseLayoutFeedbackProperties } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback/BaseLayoutFeedback';
 
 export const LayoutA0FeedbackProperties = {
   ...BaseLayoutFeedbackProperties,
 
-  canvas: Type.Optional(PixmapFeedbackComponent),
-  'full-canvas': Type.Optional(PixmapFeedbackComponent),
+  canvas: Type.Optional(WrappedPixmapFeedbackComponent),
+  'full-canvas': Type.Optional(WrappedPixmapFeedbackComponent),
 };
 export const LayoutA0Feedback = Type.Object(LayoutA0FeedbackProperties);
 export type LayoutA0Feedback = Static<typeof LayoutA0Feedback>;

--- a/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutA0Feedback.ts
+++ b/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutA0Feedback.ts
@@ -1,0 +1,13 @@
+import { Static, Type } from '@sinclair/typebox';
+
+import { PixmapFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components';
+import { BaseLayoutFeedbackProperties } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback/BaseLayoutFeedback';
+
+export const LayoutA0FeedbackProperties = {
+  ...BaseLayoutFeedbackProperties,
+
+  canvas: Type.Optional(PixmapFeedbackComponent),
+  'full-canvas': Type.Optional(PixmapFeedbackComponent),
+};
+export const LayoutA0Feedback = Type.Object(LayoutA0FeedbackProperties);
+export type LayoutA0Feedback = Static<typeof LayoutA0Feedback>;

--- a/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutA1Feedback.ts
+++ b/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutA1Feedback.ts
@@ -1,12 +1,12 @@
 import { Static, Type } from '@sinclair/typebox';
 
-import { TextFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components';
+import { WrappedTextFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components/TextFeedbackComponent';
 import { IconLayoutFeedbackProperties } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback/BaseLayoutFeedback';
 
 export const LayoutA1FeedbackProperties = {
   ...IconLayoutFeedbackProperties,
 
-  value: Type.Optional(Type.Union([TextFeedbackComponent, Type.String(), Type.Number()])),
+  value: Type.Optional(WrappedTextFeedbackComponent),
 };
 export const LayoutA1Feedback = Type.Object(LayoutA1FeedbackProperties);
 export type LayoutA1Feedback = Static<typeof LayoutA1Feedback>;

--- a/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutA1Feedback.ts
+++ b/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutA1Feedback.ts
@@ -1,0 +1,12 @@
+import { Static, Type } from '@sinclair/typebox';
+
+import { TextFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components';
+import { IconLayoutFeedbackProperties } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback/BaseLayoutFeedback';
+
+export const LayoutA1FeedbackProperties = {
+  ...IconLayoutFeedbackProperties,
+
+  value: Type.Optional(Type.Union([TextFeedbackComponent, Type.String(), Type.Number()])),
+};
+export const LayoutA1Feedback = Type.Object(LayoutA1FeedbackProperties);
+export type LayoutA1Feedback = Static<typeof LayoutA1Feedback>;

--- a/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutB1Feedback.ts
+++ b/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutB1Feedback.ts
@@ -1,0 +1,13 @@
+import { Static, Type } from '@sinclair/typebox';
+
+import { BarFeedbackComponent, TextFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components';
+import { IconLayoutFeedbackProperties } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback/BaseLayoutFeedback';
+
+export const LayoutB1FeedbackProperties = {
+  ...IconLayoutFeedbackProperties,
+
+  indicator: Type.Optional(BarFeedbackComponent),
+  value: Type.Optional(Type.Union([TextFeedbackComponent, Type.String(), Type.Number()])),
+};
+export const LayoutB1Feedback = Type.Object(LayoutB1FeedbackProperties);
+export type LayoutB1Feedback = Static<typeof LayoutB1Feedback>;

--- a/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutB1Feedback.ts
+++ b/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutB1Feedback.ts
@@ -1,13 +1,14 @@
 import { Static, Type } from '@sinclair/typebox';
 
-import { BarFeedbackComponent, TextFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components';
+import { WrappedBarFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components/BarFeedbackComponent';
+import { WrappedTextFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components/TextFeedbackComponent';
 import { IconLayoutFeedbackProperties } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback/BaseLayoutFeedback';
 
 export const LayoutB1FeedbackProperties = {
   ...IconLayoutFeedbackProperties,
 
-  indicator: Type.Optional(BarFeedbackComponent),
-  value: Type.Optional(Type.Union([TextFeedbackComponent, Type.String(), Type.Number()])),
+  indicator: Type.Optional(WrappedBarFeedbackComponent),
+  value: Type.Optional(WrappedTextFeedbackComponent),
 };
 export const LayoutB1Feedback = Type.Object(LayoutB1FeedbackProperties);
 export type LayoutB1Feedback = Static<typeof LayoutB1Feedback>;

--- a/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutB2Feedback.ts
+++ b/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutB2Feedback.ts
@@ -1,12 +1,12 @@
 import { Static, Type } from '@sinclair/typebox';
 
-import { GrooveBarFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components';
+import { WrappedGrooveBarFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components/GrooveBarFeedbackComponent';
 import { LayoutB1FeedbackProperties } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutB1Feedback';
 
 export const LayoutB2FeedbackProperties = {
   ...LayoutB1FeedbackProperties,
 
-  indicator: Type.Optional(GrooveBarFeedbackComponent),
+  indicator: Type.Optional(WrappedGrooveBarFeedbackComponent),
 };
 export const LayoutB2Feedback = Type.Object(LayoutB2FeedbackProperties);
 export type LayoutB2Feedback = Static<typeof LayoutB2Feedback>;

--- a/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutB2Feedback.ts
+++ b/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutB2Feedback.ts
@@ -1,0 +1,12 @@
+import { Static, Type } from '@sinclair/typebox';
+
+import { GrooveBarFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components';
+import { LayoutB1FeedbackProperties } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutB1Feedback';
+
+export const LayoutB2FeedbackProperties = {
+  ...LayoutB1FeedbackProperties,
+
+  indicator: Type.Optional(GrooveBarFeedbackComponent),
+};
+export const LayoutB2Feedback = Type.Object(LayoutB2FeedbackProperties);
+export type LayoutB2Feedback = Static<typeof LayoutB2Feedback>;

--- a/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutC1Feedback.ts
+++ b/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutC1Feedback.ts
@@ -1,15 +1,16 @@
 import { Static, Type } from '@sinclair/typebox';
 
-import { BarFeedbackComponent, PixmapFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components';
+import { WrappedBarFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components/BarFeedbackComponent';
+import { WrappedPixmapFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components/PixmapFeedbackComponent';
 import { BaseLayoutFeedbackProperties } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback/BaseLayoutFeedback';
 
 export const LayoutC1FeedbackProperties = {
   ...BaseLayoutFeedbackProperties,
 
-  icon1: Type.Optional(PixmapFeedbackComponent),
-  icon2: Type.Optional(PixmapFeedbackComponent),
-  indicator1: Type.Optional(BarFeedbackComponent),
-  indicator2: Type.Optional(BarFeedbackComponent),
+  icon1: Type.Optional(WrappedPixmapFeedbackComponent),
+  icon2: Type.Optional(WrappedPixmapFeedbackComponent),
+  indicator1: Type.Optional(WrappedBarFeedbackComponent),
+  indicator2: Type.Optional(WrappedBarFeedbackComponent),
 };
 export const LayoutC1Feedback = Type.Object(LayoutC1FeedbackProperties);
 export type LayoutC1Feedback = Static<typeof LayoutC1Feedback>;

--- a/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutC1Feedback.ts
+++ b/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutC1Feedback.ts
@@ -1,0 +1,15 @@
+import { Static, Type } from '@sinclair/typebox';
+
+import { BarFeedbackComponent, PixmapFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components';
+import { BaseLayoutFeedbackProperties } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback/BaseLayoutFeedback';
+
+export const LayoutC1FeedbackProperties = {
+  ...BaseLayoutFeedbackProperties,
+
+  icon1: Type.Optional(PixmapFeedbackComponent),
+  icon2: Type.Optional(PixmapFeedbackComponent),
+  indicator1: Type.Optional(BarFeedbackComponent),
+  indicator2: Type.Optional(BarFeedbackComponent),
+};
+export const LayoutC1Feedback = Type.Object(LayoutC1FeedbackProperties);
+export type LayoutC1Feedback = Static<typeof LayoutC1Feedback>;

--- a/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutX0Feedback.ts
+++ b/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutX0Feedback.ts
@@ -1,13 +1,13 @@
 import { Static, Type } from '@sinclair/typebox';
 
-import { PixmapFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components';
+import { WrappedPixmapFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components/PixmapFeedbackComponent';
 import { LayoutX2FeedbackProperties } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutX2Feedback';
 
 export const LayoutX0FeedbackProperties = {
   ...LayoutX2FeedbackProperties,
 
-  'arrow-ccw': Type.Optional(PixmapFeedbackComponent),
-  'arrow-cw': Type.Optional(PixmapFeedbackComponent),
+  'arrow-ccw': Type.Optional(WrappedPixmapFeedbackComponent),
+  'arrow-cw': Type.Optional(WrappedPixmapFeedbackComponent),
 };
 export const LayoutX0Feedback = Type.Object(LayoutX0FeedbackProperties);
 export type LayoutX0Feedback = Static<typeof LayoutX0Feedback>;

--- a/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutX0Feedback.ts
+++ b/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutX0Feedback.ts
@@ -1,0 +1,13 @@
+import { Static, Type } from '@sinclair/typebox';
+
+import { PixmapFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components';
+import { LayoutX2FeedbackProperties } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutX2Feedback';
+
+export const LayoutX0FeedbackProperties = {
+  ...LayoutX2FeedbackProperties,
+
+  'arrow-ccw': Type.Optional(PixmapFeedbackComponent),
+  'arrow-cw': Type.Optional(PixmapFeedbackComponent),
+};
+export const LayoutX0Feedback = Type.Object(LayoutX0FeedbackProperties);
+export type LayoutX0Feedback = Static<typeof LayoutX0Feedback>;

--- a/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutX1Feedback.ts
+++ b/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutX1Feedback.ts
@@ -1,12 +1,12 @@
 import { Static, Type } from '@sinclair/typebox';
 
-import { PixmapFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components';
+import { WrappedPixmapFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components/PixmapFeedbackComponent';
 import { LayoutX0FeedbackProperties } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutX0Feedback';
 
 export const LayoutX1FeedbackProperties = {
   ...LayoutX0FeedbackProperties,
 
-  'dial-press': Type.Optional(PixmapFeedbackComponent),
+  'dial-press': Type.Optional(WrappedPixmapFeedbackComponent),
 };
 export const LayoutX1Feedback = Type.Object(LayoutX1FeedbackProperties);
 export type LayoutX1Feedback = Static<typeof LayoutX1Feedback>;

--- a/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutX1Feedback.ts
+++ b/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutX1Feedback.ts
@@ -1,0 +1,12 @@
+import { Static, Type } from '@sinclair/typebox';
+
+import { PixmapFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components';
+import { LayoutX0FeedbackProperties } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutX0Feedback';
+
+export const LayoutX1FeedbackProperties = {
+  ...LayoutX0FeedbackProperties,
+
+  'dial-press': Type.Optional(PixmapFeedbackComponent),
+};
+export const LayoutX1Feedback = Type.Object(LayoutX1FeedbackProperties);
+export type LayoutX1Feedback = Static<typeof LayoutX1Feedback>;

--- a/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutX2Feedback.ts
+++ b/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutX2Feedback.ts
@@ -1,0 +1,12 @@
+import { Static, Type } from '@sinclair/typebox';
+
+import { PixmapFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components';
+import { IconLayoutFeedbackProperties } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback/BaseLayoutFeedback';
+
+export const LayoutX2FeedbackProperties = {
+  ...IconLayoutFeedbackProperties,
+
+  shutter: Type.Optional(PixmapFeedbackComponent),
+};
+export const LayoutX2Feedback = Type.Object(LayoutX2FeedbackProperties);
+export type LayoutX2Feedback = Static<typeof LayoutX2Feedback>;

--- a/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutX2Feedback.ts
+++ b/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/LayoutX2Feedback.ts
@@ -1,12 +1,12 @@
 import { Static, Type } from '@sinclair/typebox';
 
-import { PixmapFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components';
+import { WrappedPixmapFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components/PixmapFeedbackComponent';
 import { IconLayoutFeedbackProperties } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback/BaseLayoutFeedback';
 
 export const LayoutX2FeedbackProperties = {
   ...IconLayoutFeedbackProperties,
 
-  shutter: Type.Optional(PixmapFeedbackComponent),
+  shutter: Type.Optional(WrappedPixmapFeedbackComponent),
 };
 export const LayoutX2Feedback = Type.Object(LayoutX2FeedbackProperties);
 export type LayoutX2Feedback = Static<typeof LayoutX2Feedback>;

--- a/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/index.ts
+++ b/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/index.ts
@@ -1,3 +1,5 @@
+import { Static } from '@sinclair/typebox';
+
 import { LayoutA0Feedback } from './LayoutA0Feedback';
 import { LayoutA1Feedback } from './LayoutA1Feedback';
 import { LayoutB1Feedback } from './LayoutB1Feedback';
@@ -16,13 +18,16 @@ export { LayoutX0Feedback } from './LayoutX0Feedback';
 export { LayoutX1Feedback } from './LayoutX1Feedback';
 export { LayoutX2Feedback } from './LayoutX2Feedback';
 
-export type LayoutFeedbackKey = '$A0' | '$A1' | '$B1' | '$B2' | '$C1' | '$X0' | '$X1' | '$X2';
-export type LayoutFeedback =
-  | LayoutA0Feedback
-  | LayoutA1Feedback
-  | LayoutB1Feedback
-  | LayoutB2Feedback
-  | LayoutC1Feedback
-  | LayoutX0Feedback
-  | LayoutX1Feedback
-  | LayoutX2Feedback;
+export const LayoutFeedbackMapping = {
+  $A0: LayoutA0Feedback,
+  $A1: LayoutA1Feedback,
+  $B1: LayoutB1Feedback,
+  $B2: LayoutB2Feedback,
+  $C1: LayoutC1Feedback,
+  $X0: LayoutX0Feedback,
+  $X1: LayoutX1Feedback,
+  $X2: LayoutX2Feedback,
+};
+
+export type LayoutFeedbackKey = keyof typeof LayoutFeedbackMapping;
+export type LayoutFeedback = Static<typeof LayoutFeedbackMapping[LayoutFeedbackKey]>;

--- a/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/index.ts
+++ b/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/index.ts
@@ -9,6 +9,7 @@ import { LayoutX0Feedback } from './LayoutX0Feedback';
 import { LayoutX1Feedback } from './LayoutX1Feedback';
 import { LayoutX2Feedback } from './LayoutX2Feedback';
 
+export { GenericLayoutFeedback } from './BaseLayoutFeedback';
 export { LayoutA0Feedback } from './LayoutA0Feedback';
 export { LayoutA1Feedback } from './LayoutA1Feedback';
 export { LayoutB1Feedback } from './LayoutB1Feedback';

--- a/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/index.ts
+++ b/src/StreamdeckTypes/Received/Feedback/LayoutFeedback/index.ts
@@ -1,0 +1,28 @@
+import { LayoutA0Feedback } from './LayoutA0Feedback';
+import { LayoutA1Feedback } from './LayoutA1Feedback';
+import { LayoutB1Feedback } from './LayoutB1Feedback';
+import { LayoutB2Feedback } from './LayoutB2Feedback';
+import { LayoutC1Feedback } from './LayoutC1Feedback';
+import { LayoutX0Feedback } from './LayoutX0Feedback';
+import { LayoutX1Feedback } from './LayoutX1Feedback';
+import { LayoutX2Feedback } from './LayoutX2Feedback';
+
+export { LayoutA0Feedback } from './LayoutA0Feedback';
+export { LayoutA1Feedback } from './LayoutA1Feedback';
+export { LayoutB1Feedback } from './LayoutB1Feedback';
+export { LayoutB2Feedback } from './LayoutB2Feedback';
+export { LayoutC1Feedback } from './LayoutC1Feedback';
+export { LayoutX0Feedback } from './LayoutX0Feedback';
+export { LayoutX1Feedback } from './LayoutX1Feedback';
+export { LayoutX2Feedback } from './LayoutX2Feedback';
+
+export type LayoutFeedbackKey = '$A0' | '$A1' | '$B1' | '$B2' | '$C1' | '$X0' | '$X1' | '$X2';
+export type LayoutFeedback =
+  | LayoutA0Feedback
+  | LayoutA1Feedback
+  | LayoutB1Feedback
+  | LayoutB2Feedback
+  | LayoutC1Feedback
+  | LayoutX0Feedback
+  | LayoutX1Feedback
+  | LayoutX2Feedback;

--- a/src/StreamdeckTypes/Received/Feedback/Misc/TextTypes.ts
+++ b/src/StreamdeckTypes/Received/Feedback/Misc/TextTypes.ts
@@ -1,0 +1,30 @@
+export enum FontFamily {
+  ARIAL = 'Arial',
+  ARIAL_BLACK = 'Arial Black',
+  COMIC_SANS_MS = 'Comic Sans MS',
+  COURIER = 'Courier',
+  COURIER_NEW = 'Courier New',
+  GEORGIA = 'Georgia',
+  IMPACT = 'Impact',
+  MS_SANS_SERIF = 'Microsoft Sans Serif',
+  SYMBOL = 'Symbol',
+  TAHOMA = 'Tahoma',
+  TIMES_NEW_ROMAN = 'Times New Roman',
+  TREBUCHET_MS = 'Trebuchet MS',
+  VERDANA = 'Verdana',
+  WEBDINGS = 'Webdings',
+  WINGDINGS = 'Wingdings',
+}
+
+export enum FontStyle {
+  REGULAR = 'Regular',
+  BOLD = 'Bold',
+  ITALIC = 'Italic',
+  BOLD_ITALIC = 'BoldItalic',
+}
+
+export enum TextAlignment {
+  LEFT = 'left',
+  CENTER = 'center',
+  RIGHT = 'right',
+}

--- a/src/StreamdeckTypes/Received/Feedback/Misc/ValueWrapper.ts
+++ b/src/StreamdeckTypes/Received/Feedback/Misc/ValueWrapper.ts
@@ -1,0 +1,9 @@
+import { TSchema, Type } from '@sinclair/typebox';
+
+export const ValueWrapper = <T extends TSchema>(type: T) =>
+  Type.Union([
+    type,
+    Type.Object({
+      value: type,
+    }),
+  ]);

--- a/src/StreamdeckTypes/Received/SetFeedbackLayoutType.ts
+++ b/src/StreamdeckTypes/Received/SetFeedbackLayoutType.ts
@@ -1,0 +1,12 @@
+import {BaseSetterProperties} from "@/StreamdeckTypes/Received/BaseSetterType";
+import {Static, Type} from "@sinclair/typebox";
+
+export const SetFeedbackLayoutType = Type.Object({
+  ...BaseSetterProperties,
+  event: Type.RegEx(/^setFeedbackLayout$/),
+  payload: Type.Object({
+    // FIXME: This should be constrained to only permitted layouts, but Elgato has yet to release docs.
+    layout: Type.String()
+  }),
+});
+export type SetFeedbackLayoutType = Static<typeof SetFeedbackLayoutType>;

--- a/src/StreamdeckTypes/Received/SetFeedbackLayoutType.ts
+++ b/src/StreamdeckTypes/Received/SetFeedbackLayoutType.ts
@@ -1,13 +1,12 @@
 import { Static, Type } from '@sinclair/typebox';
 
 import { BaseSetterProperties } from '@/StreamdeckTypes/Received/BaseSetterType';
-import { LayoutFeedbackMapping } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback';
 
 export const SetFeedbackLayoutType = Type.Object({
   ...BaseSetterProperties,
   event: Type.RegEx(/^setFeedbackLayout$/),
   payload: Type.Object({
-    layout: Type.KeyOf(Type.Object(LayoutFeedbackMapping)),
+    layout: Type.String(),
   }),
 });
 export type SetFeedbackLayoutType = Static<typeof SetFeedbackLayoutType>;

--- a/src/StreamdeckTypes/Received/SetFeedbackLayoutType.ts
+++ b/src/StreamdeckTypes/Received/SetFeedbackLayoutType.ts
@@ -1,12 +1,13 @@
 import { Static, Type } from '@sinclair/typebox';
 
 import { BaseSetterProperties } from '@/StreamdeckTypes/Received/BaseSetterType';
+import { LayoutFeedbackMapping } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback';
 
 export const SetFeedbackLayoutType = Type.Object({
   ...BaseSetterProperties,
   event: Type.RegEx(/^setFeedbackLayout$/),
   payload: Type.Object({
-    layout: Type.RegEx(/^\$(A[01]|B[12]|C1|X[0-2])$/),
+    layout: Type.KeyOf(Type.Object(LayoutFeedbackMapping)),
   }),
 });
 export type SetFeedbackLayoutType = Static<typeof SetFeedbackLayoutType>;

--- a/src/StreamdeckTypes/Received/SetFeedbackLayoutType.ts
+++ b/src/StreamdeckTypes/Received/SetFeedbackLayoutType.ts
@@ -1,12 +1,13 @@
-import {BaseSetterProperties} from "@/StreamdeckTypes/Received/BaseSetterType";
-import {Static, Type} from "@sinclair/typebox";
+import { Static, Type } from '@sinclair/typebox';
+
+import { BaseSetterProperties } from '@/StreamdeckTypes/Received/BaseSetterType';
 
 export const SetFeedbackLayoutType = Type.Object({
   ...BaseSetterProperties,
   event: Type.RegEx(/^setFeedbackLayout$/),
   payload: Type.Object({
     // FIXME: This should be constrained to only permitted layouts, but Elgato has yet to release docs.
-    layout: Type.String()
+    layout: Type.String(),
   }),
 });
 export type SetFeedbackLayoutType = Static<typeof SetFeedbackLayoutType>;

--- a/src/StreamdeckTypes/Received/SetFeedbackLayoutType.ts
+++ b/src/StreamdeckTypes/Received/SetFeedbackLayoutType.ts
@@ -6,8 +6,7 @@ export const SetFeedbackLayoutType = Type.Object({
   ...BaseSetterProperties,
   event: Type.RegEx(/^setFeedbackLayout$/),
   payload: Type.Object({
-    // FIXME: This should be constrained to only permitted layouts, but Elgato has yet to release docs.
-    layout: Type.String(),
+    layout: Type.RegEx(/^\$(A[01]|B[12]|C1|X[0-2])$/),
   }),
 });
 export type SetFeedbackLayoutType = Static<typeof SetFeedbackLayoutType>;

--- a/src/StreamdeckTypes/Received/SetFeedbackType.ts
+++ b/src/StreamdeckTypes/Received/SetFeedbackType.ts
@@ -1,31 +1,13 @@
 import { Static, Type } from '@sinclair/typebox';
 
 import { BaseSetterProperties } from '@/StreamdeckTypes/Received/BaseSetterType';
-import {
-  LayoutA0Feedback,
-  LayoutA1Feedback,
-  LayoutB1Feedback,
-  LayoutB2Feedback,
-  LayoutC1Feedback,
-  LayoutX0Feedback,
-  LayoutX1Feedback,
-  LayoutX2Feedback,
-} from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback';
+import { LayoutFeedbackMapping } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback';
 
 export const SetFeedbackType = Type.Object({
   ...BaseSetterProperties,
   event: Type.RegEx(/^setFeedback$/),
   // FIXME: The exact types of payload are *highly* variable and depend on a lot of things. Actual definition of this
   //        will likely need to wait until Elgato releases official documentation.
-  payload: Type.Union([
-    LayoutA0Feedback,
-    LayoutA1Feedback,
-    LayoutB1Feedback,
-    LayoutB2Feedback,
-    LayoutC1Feedback,
-    LayoutX0Feedback,
-    LayoutX1Feedback,
-    LayoutX2Feedback,
-  ]),
+  payload: Type.Union(Object.values(LayoutFeedbackMapping)),
 });
 export type SetFeedbackType = Static<typeof SetFeedbackType>;

--- a/src/StreamdeckTypes/Received/SetFeedbackType.ts
+++ b/src/StreamdeckTypes/Received/SetFeedbackType.ts
@@ -1,13 +1,11 @@
 import { Static, Type } from '@sinclair/typebox';
 
 import { BaseSetterProperties } from '@/StreamdeckTypes/Received/BaseSetterType';
-import { LayoutFeedbackMapping } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback';
+import { GenericLayoutFeedback } from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback';
 
 export const SetFeedbackType = Type.Object({
   ...BaseSetterProperties,
   event: Type.RegEx(/^setFeedback$/),
-  // FIXME: The exact types of payload are *highly* variable and depend on a lot of things. Actual definition of this
-  //        will likely need to wait until Elgato releases official documentation.
-  payload: Type.Union(Object.values(LayoutFeedbackMapping)),
+  payload: GenericLayoutFeedback,
 });
 export type SetFeedbackType = Static<typeof SetFeedbackType>;

--- a/src/StreamdeckTypes/Received/SetFeedbackType.ts
+++ b/src/StreamdeckTypes/Received/SetFeedbackType.ts
@@ -1,0 +1,11 @@
+import {Static, Type} from "@sinclair/typebox";
+import {BaseSetterProperties} from "@/StreamdeckTypes/Received/BaseSetterType";
+
+export const SetFeedbackType = Type.Object({
+  ...BaseSetterProperties,
+  event: Type.RegEx(/^setFeedback$/),
+  // FIXME: The exact types of payload are *highly* variable and depend on a lot of things. Actual definition of this
+  //        will likely need to wait until Elgato releases official documentation.
+  payload: Type.Unknown()
+});
+export type SetFeedbackType = Static<typeof SetFeedbackType>;

--- a/src/StreamdeckTypes/Received/SetFeedbackType.ts
+++ b/src/StreamdeckTypes/Received/SetFeedbackType.ts
@@ -1,11 +1,31 @@
-import {Static, Type} from "@sinclair/typebox";
-import {BaseSetterProperties} from "@/StreamdeckTypes/Received/BaseSetterType";
+import { Static, Type } from '@sinclair/typebox';
+
+import { BaseSetterProperties } from '@/StreamdeckTypes/Received/BaseSetterType';
+import {
+  LayoutA0Feedback,
+  LayoutA1Feedback,
+  LayoutB1Feedback,
+  LayoutB2Feedback,
+  LayoutC1Feedback,
+  LayoutX0Feedback,
+  LayoutX1Feedback,
+  LayoutX2Feedback,
+} from '@/StreamdeckTypes/Received/Feedback/LayoutFeedback';
 
 export const SetFeedbackType = Type.Object({
   ...BaseSetterProperties,
   event: Type.RegEx(/^setFeedback$/),
   // FIXME: The exact types of payload are *highly* variable and depend on a lot of things. Actual definition of this
   //        will likely need to wait until Elgato releases official documentation.
-  payload: Type.Unknown()
+  payload: Type.Union([
+    LayoutA0Feedback,
+    LayoutA1Feedback,
+    LayoutB1Feedback,
+    LayoutB2Feedback,
+    LayoutC1Feedback,
+    LayoutX0Feedback,
+    LayoutX1Feedback,
+    LayoutX2Feedback,
+  ]),
 });
 export type SetFeedbackType = Static<typeof SetFeedbackType>;

--- a/src/StreamdeckTypes/Sent/BaseStateType.ts
+++ b/src/StreamdeckTypes/Sent/BaseStateType.ts
@@ -8,6 +8,7 @@ export const BaseStateProperties = {
   device: Type.String(),
   event: Type.RegEx(/^willAppear|willDisappear|didReceiveSettings$/),
   payload: Type.Object({
+    controller: Type.Optional(Type.RegEx(/^Keypad|Encoder$/)),
     coordinates: Type.Optional(BaseCoordinatesPayloadType),
     isInMultiAction: Type.Boolean(),
     settings: Type.Unknown(),

--- a/src/StreamdeckTypes/Sent/BaseStateType.ts
+++ b/src/StreamdeckTypes/Sent/BaseStateType.ts
@@ -2,18 +2,19 @@ import { Static, Type } from '@sinclair/typebox';
 
 import { BaseCoordinatesPayloadType } from './BaseCoordinatesPayloadType';
 
+export const BaseStatePayloadProperties = {
+  coordinates: Type.Optional(BaseCoordinatesPayloadType),
+  isInMultiAction: Type.Boolean(),
+  settings: Type.Unknown(),
+  state: Type.Optional(Type.Number()),
+};
+
 export const BaseStateProperties = {
   action: Type.String(),
   context: Type.String(),
   device: Type.String(),
   event: Type.RegEx(/^willAppear|willDisappear|didReceiveSettings$/),
-  payload: Type.Object({
-    controller: Type.Optional(Type.RegEx(/^Keypad|Encoder$/)),
-    coordinates: Type.Optional(BaseCoordinatesPayloadType),
-    isInMultiAction: Type.Boolean(),
-    settings: Type.Unknown(),
-    state: Type.Optional(Type.Number()),
-  }),
+  payload: Type.Object(BaseStatePayloadProperties),
 };
 
 export const BaseStateType = Type.Object(BaseStateProperties);

--- a/src/StreamdeckTypes/Sent/BaseVisibilityType.ts
+++ b/src/StreamdeckTypes/Sent/BaseVisibilityType.ts
@@ -8,7 +8,7 @@ export const BaseVisibilityProperties = {
   event: Type.RegEx(/^willAppear|willDisappear$/),
   payload: Type.Object({
     ...BaseStatePayloadProperties,
-    controller: Type.Enum(ControllerType),
+    controller: Type.Optional(Type.Enum(ControllerType, { default: ControllerType.Keypad })),
   }),
 };
 

--- a/src/StreamdeckTypes/Sent/BaseVisibilityType.ts
+++ b/src/StreamdeckTypes/Sent/BaseVisibilityType.ts
@@ -1,0 +1,16 @@
+import { Static, Type } from '@sinclair/typebox';
+
+import { ControllerType } from '@/Events/Received/Plugin/ControllerType';
+import { BaseStatePayloadProperties, BaseStateProperties } from '@/StreamdeckTypes/Sent/BaseStateType';
+
+export const BaseVisibilityProperties = {
+  ...BaseStateProperties,
+  event: Type.RegEx(/^willAppear|willDisappear$/),
+  payload: Type.Object({
+    ...BaseStatePayloadProperties,
+    controller: Type.Enum(ControllerType),
+  }),
+};
+
+export const BaseVisibilityType = Type.Object(BaseVisibilityProperties);
+export type BaseVisibilityType = Static<typeof BaseVisibilityType>;

--- a/src/StreamdeckTypes/Sent/Dial/BaseDialType.ts
+++ b/src/StreamdeckTypes/Sent/Dial/BaseDialType.ts
@@ -1,10 +1,11 @@
 import { Static, Type } from '@sinclair/typebox';
 
+import { ControllerType } from '@/Events/Received/Plugin/ControllerType';
 import { BaseCoordinatesPayloadType } from '@/StreamdeckTypes/Sent/BaseCoordinatesPayloadType';
 import { BaseExtendedProperties } from '@/StreamdeckTypes/Sent/BaseExtendedType';
 
 export const BaseDialPayloadProperties = {
-  controller: Type.RegEx(/^Encoder$/),
+  controller: Type.Literal(ControllerType.Encoder),
   coordinates: Type.Optional(BaseCoordinatesPayloadType),
   settings: Type.Any(),
 };

--- a/src/StreamdeckTypes/Sent/Dial/BaseDialType.ts
+++ b/src/StreamdeckTypes/Sent/Dial/BaseDialType.ts
@@ -1,0 +1,18 @@
+import {BaseExtendedProperties} from "@/StreamdeckTypes/Sent/BaseExtendedType";
+import {Static, Type} from "@sinclair/typebox";
+import {BaseCoordinatesPayloadType} from "@/StreamdeckTypes/Sent/BaseCoordinatesPayloadType";
+
+export const BaseDialPayloadProperties = {
+  controller: Type.RegEx(/^Encoder$/),
+  coordinates: Type.Optional(BaseCoordinatesPayloadType),
+  settings: Type.Any()
+};
+
+export const BaseDialProperties = {
+  ...BaseExtendedProperties,
+  event: Type.RegEx(/^dialPress|dialRotate|touchTap$/),
+  payload: Type.Object(BaseDialPayloadProperties),
+};
+
+export const BaseDialType = Type.Object(BaseDialProperties);
+export type BaseDialType = Static<typeof BaseDialType>;

--- a/src/StreamdeckTypes/Sent/Dial/BaseDialType.ts
+++ b/src/StreamdeckTypes/Sent/Dial/BaseDialType.ts
@@ -1,11 +1,12 @@
-import {BaseExtendedProperties} from "@/StreamdeckTypes/Sent/BaseExtendedType";
-import {Static, Type} from "@sinclair/typebox";
-import {BaseCoordinatesPayloadType} from "@/StreamdeckTypes/Sent/BaseCoordinatesPayloadType";
+import { Static, Type } from '@sinclair/typebox';
+
+import { BaseCoordinatesPayloadType } from '@/StreamdeckTypes/Sent/BaseCoordinatesPayloadType';
+import { BaseExtendedProperties } from '@/StreamdeckTypes/Sent/BaseExtendedType';
 
 export const BaseDialPayloadProperties = {
   controller: Type.RegEx(/^Encoder$/),
   coordinates: Type.Optional(BaseCoordinatesPayloadType),
-  settings: Type.Any()
+  settings: Type.Any(),
 };
 
 export const BaseDialProperties = {

--- a/src/StreamdeckTypes/Sent/Dial/BaseEncoderType.ts
+++ b/src/StreamdeckTypes/Sent/Dial/BaseEncoderType.ts
@@ -1,15 +1,16 @@
-import { Static, Type } from "@sinclair/typebox";
-import {BaseDialPayloadProperties, BaseDialProperties} from "@/StreamdeckTypes/Sent/Dial/BaseDialType";
+import { Static, Type } from '@sinclair/typebox';
+
+import { BaseDialPayloadProperties, BaseDialProperties } from '@/StreamdeckTypes/Sent/Dial/BaseDialType';
 
 export const BaseEncoderPayloadProperties = {
   ...BaseDialPayloadProperties,
-  pressed: Type.Boolean()
+  pressed: Type.Boolean(),
 };
 
 export const BaseEncoderProperties = {
   ...BaseDialProperties,
   event: Type.RegEx(/^dialPress|dialRotate$/),
-  payload: Type.Object(BaseEncoderPayloadProperties)
+  payload: Type.Object(BaseEncoderPayloadProperties),
 };
 
 export const BaseEncoderType = Type.Object(BaseEncoderProperties);

--- a/src/StreamdeckTypes/Sent/Dial/BaseEncoderType.ts
+++ b/src/StreamdeckTypes/Sent/Dial/BaseEncoderType.ts
@@ -1,0 +1,16 @@
+import { Static, Type } from "@sinclair/typebox";
+import {BaseDialPayloadProperties, BaseDialProperties} from "@/StreamdeckTypes/Sent/Dial/BaseDialType";
+
+export const BaseEncoderPayloadProperties = {
+  ...BaseDialPayloadProperties,
+  pressed: Type.Boolean()
+};
+
+export const BaseEncoderProperties = {
+  ...BaseDialProperties,
+  event: Type.RegEx(/^dialPress|dialRotate$/),
+  payload: Type.Object(BaseEncoderPayloadProperties)
+};
+
+export const BaseEncoderType = Type.Object(BaseEncoderProperties);
+export type BaseEncoderType = Static<typeof BaseEncoderType>;

--- a/src/StreamdeckTypes/Sent/Dial/DialPressEventType.ts
+++ b/src/StreamdeckTypes/Sent/Dial/DialPressEventType.ts
@@ -1,5 +1,6 @@
 import { Static, Type } from '@sinclair/typebox';
-import {BaseEncoderProperties, BaseEncoderPayloadProperties} from "./BaseEncoderType";
+
+import { BaseEncoderPayloadProperties, BaseEncoderProperties } from './BaseEncoderType';
 
 export const DialPressPayloadProperties = {
   ...BaseEncoderPayloadProperties,
@@ -8,7 +9,7 @@ export const DialPressPayloadProperties = {
 export const DialPressEventProperties = {
   ...BaseEncoderProperties,
   event: Type.RegEx(/^dialPress$/),
-  payload: Type.Object(DialPressPayloadProperties)
+  payload: Type.Object(DialPressPayloadProperties),
 };
 
 export const DialPressEventType = Type.Object(DialPressEventProperties);

--- a/src/StreamdeckTypes/Sent/Dial/DialPressEventType.ts
+++ b/src/StreamdeckTypes/Sent/Dial/DialPressEventType.ts
@@ -1,0 +1,15 @@
+import { Static, Type } from '@sinclair/typebox';
+import {BaseEncoderProperties, BaseEncoderPayloadProperties} from "./BaseEncoderType";
+
+export const DialPressPayloadProperties = {
+  ...BaseEncoderPayloadProperties,
+};
+
+export const DialPressEventProperties = {
+  ...BaseEncoderProperties,
+  event: Type.RegEx(/^dialPress$/),
+  payload: Type.Object(DialPressPayloadProperties)
+};
+
+export const DialPressEventType = Type.Object(DialPressEventProperties);
+export type DialPressEventType = Static<typeof DialPressEventType>;

--- a/src/StreamdeckTypes/Sent/Dial/DialRotateEventType.ts
+++ b/src/StreamdeckTypes/Sent/Dial/DialRotateEventType.ts
@@ -1,15 +1,16 @@
 import { Static, Type } from '@sinclair/typebox';
-import {BaseEncoderProperties, BaseEncoderPayloadProperties} from "./BaseEncoderType";
+
+import { BaseEncoderPayloadProperties, BaseEncoderProperties } from './BaseEncoderType';
 
 export const DialRotatePayloadProperties = {
   ...BaseEncoderPayloadProperties,
-  ticks: Type.Number()
+  ticks: Type.Number(),
 };
 
 export const DialRotateEventProperties = {
   ...BaseEncoderProperties,
   event: Type.RegEx(/^dialRotate$/),
-  payload: Type.Object(DialRotatePayloadProperties)
+  payload: Type.Object(DialRotatePayloadProperties),
 };
 
 export const DialRotateEventType = Type.Object(DialRotateEventProperties);

--- a/src/StreamdeckTypes/Sent/Dial/DialRotateEventType.ts
+++ b/src/StreamdeckTypes/Sent/Dial/DialRotateEventType.ts
@@ -1,0 +1,16 @@
+import { Static, Type } from '@sinclair/typebox';
+import {BaseEncoderProperties, BaseEncoderPayloadProperties} from "./BaseEncoderType";
+
+export const DialRotatePayloadProperties = {
+  ...BaseEncoderPayloadProperties,
+  ticks: Type.Number()
+};
+
+export const DialRotateEventProperties = {
+  ...BaseEncoderProperties,
+  event: Type.RegEx(/^dialRotate$/),
+  payload: Type.Object(DialRotatePayloadProperties)
+};
+
+export const DialRotateEventType = Type.Object(DialRotateEventProperties);
+export type DialRotateEventType = Static<typeof DialRotateEventType>;

--- a/src/StreamdeckTypes/Sent/Dial/TouchTapEventType.ts
+++ b/src/StreamdeckTypes/Sent/Dial/TouchTapEventType.ts
@@ -1,17 +1,18 @@
 import { Static, Type } from '@sinclair/typebox';
-import {BaseDialPayloadProperties, BaseDialProperties} from "./BaseDialType";
+
+import { BaseDialPayloadProperties, BaseDialProperties } from './BaseDialType';
 
 export const TouchTapPayloadProperties = {
   ...BaseDialPayloadProperties,
   hold: Type.Boolean(),
-  tapPos: Type.Array(Type.Number(), {minItems: 2, maxItems: 2})
-}
+  tapPos: Type.Array(Type.Number(), { maxItems: 2, minItems: 2 }),
+};
 
 export const TouchTapEventProperties = {
   ...BaseDialProperties,
   event: Type.RegEx(/^touchTap$/),
-  payload: Type.Object(TouchTapPayloadProperties)
+  payload: Type.Object(TouchTapPayloadProperties),
 };
 
-export const TouchTapEventType = Type.Object(TouchTapEventProperties)
+export const TouchTapEventType = Type.Object(TouchTapEventProperties);
 export type TouchTapEventType = Static<typeof TouchTapEventType>;

--- a/src/StreamdeckTypes/Sent/Dial/TouchTapEventType.ts
+++ b/src/StreamdeckTypes/Sent/Dial/TouchTapEventType.ts
@@ -5,7 +5,7 @@ import { BaseDialPayloadProperties, BaseDialProperties } from './BaseDialType';
 export const TouchTapPayloadProperties = {
   ...BaseDialPayloadProperties,
   hold: Type.Boolean(),
-  tapPos: Type.Array(Type.Number(), { maxItems: 2, minItems: 2 }),
+  tapPos: Type.Tuple([Type.Number(), Type.Number()]),
 };
 
 export const TouchTapEventProperties = {

--- a/src/StreamdeckTypes/Sent/Dial/TouchTapEventType.ts
+++ b/src/StreamdeckTypes/Sent/Dial/TouchTapEventType.ts
@@ -1,0 +1,17 @@
+import { Static, Type } from '@sinclair/typebox';
+import {BaseDialPayloadProperties, BaseDialProperties} from "./BaseDialType";
+
+export const TouchTapPayloadProperties = {
+  ...BaseDialPayloadProperties,
+  hold: Type.Boolean(),
+  tapPos: Type.Array(Type.Number(), {minItems: 2, maxItems: 2})
+}
+
+export const TouchTapEventProperties = {
+  ...BaseDialProperties,
+  event: Type.RegEx(/^touchTap$/),
+  payload: Type.Object(TouchTapPayloadProperties)
+};
+
+export const TouchTapEventType = Type.Object(TouchTapEventProperties)
+export type TouchTapEventType = Static<typeof TouchTapEventType>;

--- a/src/StreamdeckTypes/Sent/Dial/index.ts
+++ b/src/StreamdeckTypes/Sent/Dial/index.ts
@@ -1,0 +1,2 @@
+export * from './DialPressEventType';
+export * from './DialRotateEventType';

--- a/src/StreamdeckTypes/Sent/WillAppearType.ts
+++ b/src/StreamdeckTypes/Sent/WillAppearType.ts
@@ -1,9 +1,9 @@
 import { Static, Type } from '@sinclair/typebox';
 
-import { BaseStateProperties } from '@/StreamdeckTypes/Sent/BaseStateType';
+import { BaseVisibilityProperties } from '@/StreamdeckTypes/Sent/BaseVisibilityType';
 
 export const WillAppearType = Type.Object({
-  ...BaseStateProperties,
+  ...BaseVisibilityProperties,
   event: Type.RegEx(/^willAppear$/),
 });
 export type WillAppearType = Static<typeof WillAppearType>;

--- a/src/StreamdeckTypes/Sent/WillDisappearType.ts
+++ b/src/StreamdeckTypes/Sent/WillDisappearType.ts
@@ -1,9 +1,9 @@
 import { Static, Type } from '@sinclair/typebox';
 
-import { BaseStateProperties } from '@/StreamdeckTypes/Sent/BaseStateType';
+import { BaseVisibilityProperties } from '@/StreamdeckTypes/Sent/BaseVisibilityType';
 
 export const WillDisappearType = Type.Object({
-  ...BaseStateProperties,
+  ...BaseVisibilityProperties,
   event: Type.RegEx(/^willDisappear$/),
 });
 export type WillDisappearType = Static<typeof WillDisappearType>;

--- a/test/Events/EventsSentTest.ts
+++ b/test/Events/EventsSentTest.ts
@@ -72,15 +72,15 @@ describe('EventsSent test', () => {
     expect(parsed.payload.a).to.equal('payload');
   });
   it('creates the SetFeedbackEvent', () => {
-    let event = new EventsSent().setFeedback({"value": "hello world"}, 'ctx');
-    expect(JSON.parse(JSON.stringify(event)).payload.value).to.equal("hello world");
+    let event = new EventsSent().setFeedback({ value: 'hello world' }, 'ctx');
+    expect(JSON.parse(JSON.stringify(event)).payload.value).to.equal('hello world');
 
-    event = new EventsSent().setFeedback({"title": {"value": "titled"}}, 'ctx');
-    expect(JSON.parse(JSON.stringify(event)).payload.title.value).to.equal("titled");
+    event = new EventsSent().setFeedback({ title: { value: 'titled' } }, 'ctx');
+    expect(JSON.parse(JSON.stringify(event)).payload.title.value).to.equal('titled');
   });
   it('creates the SetFeedbackLayoutEvent', () => {
-    let event = new EventsSent().setFeedbackLayout("$B0", "ctx");
-    expect(JSON.parse(JSON.stringify(event)).payload.layout).to.equal("$B0");
+    const event = new EventsSent().setFeedbackLayout('$B1', 'ctx');
+    expect(JSON.parse(JSON.stringify(event)).payload.layout).to.equal('$B1');
   });
   it('creates the SetImageEvent', () => {
     let event = new EventsSent().setImage('theimage', 'thecontext', 'software');

--- a/test/Events/EventsSentTest.ts
+++ b/test/Events/EventsSentTest.ts
@@ -71,6 +71,17 @@ describe('EventsSent test', () => {
     expect(parsed.action).to.equal('aaction');
     expect(parsed.payload.a).to.equal('payload');
   });
+  it('creates the SetFeedbackEvent', () => {
+    let event = new EventsSent().setFeedback({"value": "hello world"}, 'ctx');
+    expect(JSON.parse(JSON.stringify(event)).payload.value).to.equal("hello world");
+
+    event = new EventsSent().setFeedback({"title": {"value": "titled"}}, 'ctx');
+    expect(JSON.parse(JSON.stringify(event)).payload.title.value).to.equal("titled");
+  });
+  it('creates the SetFeedbackLayoutEvent', () => {
+    let event = new EventsSent().setFeedbackLayout("$B0", "ctx");
+    expect(JSON.parse(JSON.stringify(event)).payload.layout).to.equal("$B0");
+  });
   it('creates the SetImageEvent', () => {
     let event = new EventsSent().setImage('theimage', 'thecontext', 'software');
     const parsed: SetImageType = JSON.parse(JSON.stringify(event));

--- a/test/Events/Received/EventFactoryTest.ts
+++ b/test/Events/Received/EventFactoryTest.ts
@@ -21,18 +21,16 @@ import {
   WillAppearEvent,
   WillDisappearEvent,
 } from '@/Events/Received/Plugin';
+import { DialPressEvent, DialRotateEvent, TouchTapEvent } from '@/Events/Received/Plugin/Dial';
 import { SendToPropertyInspectorEvent } from '@/Events/Received/PropertyInspector';
-
-import {
-  DialPressEvent,
-  DialRotateEvent,
-  TouchTapEvent
-} from "@/Events/Received/Plugin/Dial";
 
 import eventAppDidLaunch from './fixtures/applicationDidLaunchEvent.valid.json';
 import eventAppDidTerminate from './fixtures/applicationDidTerminateEvent.valid.json';
 import eventDeviceconnect from './fixtures/deviceDidConnectEvent.valid.json';
 import eventDeviceDisconnect from './fixtures/deviceDidDisconnectEvent.valid.json';
+// dial events
+import eventDialPress from './fixtures/dialPressEvent/valid.json';
+import eventDialRotate from './fixtures/dialRotateEvent/valid.json';
 import eventDidReceiveGlobalSettings from './fixtures/didReceiveGlobalSettingsEvent.valid.json';
 import eventDidReceiveSettings from './fixtures/didReceiveSettingsEvent.valid.json';
 import eventKeydown from './fixtures/keyDownEvent.valid.json';
@@ -43,13 +41,9 @@ import eventSendtoplugin from './fixtures/sendToPluginEvent.valid.json';
 import eventSendtoPropertyInspector from './fixtures/sendToPropertyInspectorEvent.valid.json';
 import eventSystemDidWakeUp from './fixtures/systemDidWakeUpEvent.valid.json';
 import eventTitleparamchange from './fixtures/titleParametersDidChangeEvent.valid.json';
+import eventTouchTap from './fixtures/touchTapEvent/valid.json';
 import eventWillappear from './fixtures/willAppearEvent.valid.json';
 import eventWilldisappear from './fixtures/willDisappearEvent.valid.json';
-
-// dial events
-import eventDialPress from './fixtures/dialPressEvent/valid.json';
-import eventDialRotate from './fixtures/dialRotateEvent/valid.json';
-import eventTouchTap from './fixtures/touchTapEvent/valid.json';
 
 describe('EventFactory test', () => {
   it('throws an error if no event type is specified', () => {
@@ -142,9 +136,9 @@ describe('EventFactory test', () => {
 
   it('should return a dialRotate event', () => {
     expect(new EventFactory().createByEventPayload(eventDialRotate)).to.be.instanceOf(DialRotateEvent);
-  })
+  });
 
   it('should return a touchTap event', () => {
     expect(new EventFactory().createByEventPayload(eventTouchTap)).to.be.instanceOf(TouchTapEvent);
-  })
+  });
 });

--- a/test/Events/Received/EventFactoryTest.ts
+++ b/test/Events/Received/EventFactoryTest.ts
@@ -23,6 +23,12 @@ import {
 } from '@/Events/Received/Plugin';
 import { SendToPropertyInspectorEvent } from '@/Events/Received/PropertyInspector';
 
+import {
+  DialPressEvent,
+  DialRotateEvent,
+  TouchTapEvent
+} from "@/Events/Received/Plugin/Dial";
+
 import eventAppDidLaunch from './fixtures/applicationDidLaunchEvent.valid.json';
 import eventAppDidTerminate from './fixtures/applicationDidTerminateEvent.valid.json';
 import eventDeviceconnect from './fixtures/deviceDidConnectEvent.valid.json';
@@ -39,6 +45,11 @@ import eventSystemDidWakeUp from './fixtures/systemDidWakeUpEvent.valid.json';
 import eventTitleparamchange from './fixtures/titleParametersDidChangeEvent.valid.json';
 import eventWillappear from './fixtures/willAppearEvent.valid.json';
 import eventWilldisappear from './fixtures/willDisappearEvent.valid.json';
+
+// dial events
+import eventDialPress from './fixtures/dialPressEvent/valid.json';
+import eventDialRotate from './fixtures/dialRotateEvent/valid.json';
+import eventTouchTap from './fixtures/touchTapEvent/valid.json';
 
 describe('EventFactory test', () => {
   it('throws an error if no event type is specified', () => {
@@ -124,4 +135,16 @@ describe('EventFactory test', () => {
   it('should return a willdisappear event', () => {
     expect(new EventFactory().createByEventPayload(eventWilldisappear)).to.be.instanceOf(WillDisappearEvent);
   });
+
+  it('should return a dialPress event', () => {
+    expect(new EventFactory().createByEventPayload(eventDialPress)).to.be.instanceOf(DialPressEvent);
+  });
+
+  it('should return a dialRotate event', () => {
+    expect(new EventFactory().createByEventPayload(eventDialRotate)).to.be.instanceOf(DialRotateEvent);
+  })
+
+  it('should return a touchTap event', () => {
+    expect(new EventFactory().createByEventPayload(eventTouchTap)).to.be.instanceOf(TouchTapEvent);
+  })
 });

--- a/test/Events/Received/Plugin/DeviceDidConnectEventTest.ts
+++ b/test/Events/Received/Plugin/DeviceDidConnectEventTest.ts
@@ -33,6 +33,12 @@ describe('DeviceDidConnectEvent test', () => {
     expect(new DeviceDidConnectEvent(eventJson).typeName).to.equal('StreamDeckMobile');
     eventJson.deviceInfo.type = DeviceType.CorsairGKeys;
     expect(new DeviceDidConnectEvent(eventJson).typeName).to.equal('CorsairGKeys');
+    eventJson.deviceInfo.type = DeviceType.StreamDeckPedal;
+    expect(new DeviceDidConnectEvent(eventJson).typeName).to.equal('StreamDeckPedal');
+    eventJson.deviceInfo.type = DeviceType.CorsairVoyager;
+    expect(new DeviceDidConnectEvent(eventJson).typeName).to.equal('CorsairVoyager');
+    eventJson.deviceInfo.type = DeviceType.StreamDeckPlus;
+    expect(new DeviceDidConnectEvent(eventJson).typeName).to.equal('StreamDeckPlus');
   });
   it('should throw a validation error on missing parameters', function () {
     expect(() => new DeviceDidConnectEvent(eventMissingParameter)).to.throw(

--- a/test/Events/Received/Plugin/DialPressEventTest.ts
+++ b/test/Events/Received/Plugin/DialPressEventTest.ts
@@ -7,19 +7,19 @@ import DialPressEvent from '@/Events/Received/Plugin/Dial/DialPressEvent';
 
 import eventInvalidType from '../fixtures/dialPressEvent/invalidEvent.json';
 import eventMissingParameter from '../fixtures/dialPressEvent/missingPressed.json';
-import eventValid from '../fixtures/dialPressEvent/valid.json';
 import eventValidRelease from '../fixtures/dialPressEvent/valid.dialRelease.json';
+import eventValid from '../fixtures/dialPressEvent/valid.json';
 
 describe('DialPressEvent test', () => {
   it('should create the event when using the correct payload', function () {
     const event = new DialPressEvent(eventValid);
-    expect(event.action).to.equal("ts.streamdeck.events.dialPressTest");
-    expect(event.context).to.equal("FEDCBA9876543210FEDCBA9876543210");
-    expect(event.device).to.equal( "0123456789ABCDEF0123456789ABCDEF");
-    expect(event.event).to.equal("dialPress");
+    expect(event.action).to.equal('ts.streamdeck.events.dialPressTest');
+    expect(event.context).to.equal('FEDCBA9876543210FEDCBA9876543210');
+    expect(event.device).to.equal('0123456789ABCDEF0123456789ABCDEF');
+    expect(event.event).to.equal('dialPress');
     expect(event.column).to.equal(1);
     expect(event.row).to.equal(0);
-    expect(event.controller).to.equal("Encoder");
+    expect(event.controller).to.equal('Encoder');
     expect(event.pressed).to.be.true;
   });
   it('should create the event when using the correct payload (when released)', function () {
@@ -32,16 +32,21 @@ describe('DialPressEvent test', () => {
     const event = new DialPressEvent(eventValid);
 
     expect(event.settings).to.haveOwnProperty('key');
-    expect((event.settings as {'key': string}).key).to.equal('value');
+    expect((event.settings as { key: string }).key).to.equal('value');
 
     expect(event.settings).to.haveOwnProperty('someNum');
-    expect((event.settings as {'someNum': number}).someNum).to.equal(1234);
-
+    expect((event.settings as { someNum: number }).someNum).to.equal(1234);
   });
   it('should throw a validation error on missing pressed parameter', function () {
-    expect(() => new DialPressEvent(eventMissingParameter)).to.throw(EventValidationError, /required property 'pressed'/);
+    expect(() => new DialPressEvent(eventMissingParameter)).to.throw(
+      EventValidationError,
+      /required property 'pressed'/,
+    );
   });
   it('should throw a validation error on wrong event type', function () {
-    expect(() => new DialPressEvent(eventInvalidType)).to.throw(EventValidationError, /must match pattern "\^dialPress\$"/);
+    expect(() => new DialPressEvent(eventInvalidType)).to.throw(
+      EventValidationError,
+      /must match pattern "\^dialPress\$"/,
+    );
   });
 });

--- a/test/Events/Received/Plugin/DialPressEventTest.ts
+++ b/test/Events/Received/Plugin/DialPressEventTest.ts
@@ -1,0 +1,47 @@
+import 'mocha';
+
+import { expect } from 'chai';
+
+import EventValidationError from '@/Events/Received/Exception/EventValidationError';
+import DialPressEvent from '@/Events/Received/Plugin/Dial/DialPressEvent';
+
+import eventInvalidType from '../fixtures/dialPressEvent/invalidEvent.json';
+import eventMissingParameter from '../fixtures/dialPressEvent/missingPressed.json';
+import eventValid from '../fixtures/dialPressEvent/valid.json';
+import eventValidRelease from '../fixtures/dialPressEvent/valid.dialRelease.json';
+
+describe('DialPressEvent test', () => {
+  it('should create the event when using the correct payload', function () {
+    const event = new DialPressEvent(eventValid);
+    expect(event.action).to.equal("ts.streamdeck.events.dialPressTest");
+    expect(event.context).to.equal("FEDCBA9876543210FEDCBA9876543210");
+    expect(event.device).to.equal( "0123456789ABCDEF0123456789ABCDEF");
+    expect(event.event).to.equal("dialPress");
+    expect(event.column).to.equal(1);
+    expect(event.row).to.equal(0);
+    expect(event.controller).to.equal("Encoder");
+    expect(event.pressed).to.be.true;
+  });
+  it('should create the event when using the correct payload (when released)', function () {
+    const event = new DialPressEvent(eventValidRelease);
+
+    // only testing this, as everything else was tested above
+    expect(event.pressed).to.be.false;
+  });
+  it('should create the event with settings', function () {
+    const event = new DialPressEvent(eventValid);
+
+    expect(event.settings).to.haveOwnProperty('key');
+    expect((event.settings as {'key': string}).key).to.equal('value');
+
+    expect(event.settings).to.haveOwnProperty('someNum');
+    expect((event.settings as {'someNum': number}).someNum).to.equal(1234);
+
+  });
+  it('should throw a validation error on missing pressed parameter', function () {
+    expect(() => new DialPressEvent(eventMissingParameter)).to.throw(EventValidationError, /required property 'pressed'/);
+  });
+  it('should throw a validation error on wrong event type', function () {
+    expect(() => new DialPressEvent(eventInvalidType)).to.throw(EventValidationError, /must match pattern "\^dialPress\$"/);
+  });
+});

--- a/test/Events/Received/Plugin/DialRotateEventTest.ts
+++ b/test/Events/Received/Plugin/DialRotateEventTest.ts
@@ -1,0 +1,51 @@
+import 'mocha';
+
+import { expect } from 'chai';
+
+import EventValidationError from '@/Events/Received/Exception/EventValidationError';
+import DialRotateEvent from '@/Events/Received/Plugin/Dial/DialRotateEvent';
+
+import eventInvalidType from '../fixtures/dialRotateEvent/invalidEvent.json';
+import eventMissingParameter from '../fixtures/dialRotateEvent/missingTicks.json';
+import eventValid from '../fixtures/dialRotateEvent/valid.json';
+import eventValidCCW from '../fixtures/dialRotateEvent/valid.ccw.json';
+
+describe('DialRotateEvent test', () => {
+  it('should handle a standard rotation', function () {
+    const event = new DialRotateEvent(eventValid);
+    expect(event.action).to.equal("ts.streamdeck.events.dialRotateTest");
+    expect(event.context).to.equal("FEDCBA9876543210FEDCBA9876543210");
+    expect(event.device).to.equal( "0123456789ABCDEF0123456789ABCDEF");
+    expect(event.event).to.equal("dialRotate");
+    expect(event.column).to.equal(1);
+    expect(event.row).to.equal(0);
+    expect(event.controller).to.equal("Encoder");
+    expect(event.pressed).to.be.false;
+    expect(event.ticks).to.equal(1);
+  });
+
+  it('should handle a reverse rotation while pressed', function () {
+    const event = new DialRotateEvent(eventValidCCW);
+
+    expect(event.pressed).to.be.true;
+    expect(event.ticks).to.equal(-1);
+  });
+
+  it('should create the event with settings', function () {
+    const event = new DialRotateEvent(eventValid);
+
+    expect(event.settings).to.haveOwnProperty('key');
+    expect((event.settings as {'key': string}).key).to.equal('value');
+
+    expect(event.settings).to.haveOwnProperty('someNum');
+    expect((event.settings as {'someNum': number}).someNum).to.equal(1234);
+  });
+
+  it('should throw a validation error on missing tick parameters', function () {
+    expect(() => new DialRotateEvent(eventMissingParameter)).to.throw(EventValidationError, /required property 'ticks'/);
+  });
+
+  it('should throw a validation error on wrong event type', function () {
+    expect(() => new DialRotateEvent(eventInvalidType)).to.throw(EventValidationError, /must match pattern "\^dialRotate\$"/);
+  });
+});

--- a/test/Events/Received/Plugin/DialRotateEventTest.ts
+++ b/test/Events/Received/Plugin/DialRotateEventTest.ts
@@ -7,19 +7,19 @@ import DialRotateEvent from '@/Events/Received/Plugin/Dial/DialRotateEvent';
 
 import eventInvalidType from '../fixtures/dialRotateEvent/invalidEvent.json';
 import eventMissingParameter from '../fixtures/dialRotateEvent/missingTicks.json';
-import eventValid from '../fixtures/dialRotateEvent/valid.json';
 import eventValidCCW from '../fixtures/dialRotateEvent/valid.ccw.json';
+import eventValid from '../fixtures/dialRotateEvent/valid.json';
 
 describe('DialRotateEvent test', () => {
   it('should handle a standard rotation', function () {
     const event = new DialRotateEvent(eventValid);
-    expect(event.action).to.equal("ts.streamdeck.events.dialRotateTest");
-    expect(event.context).to.equal("FEDCBA9876543210FEDCBA9876543210");
-    expect(event.device).to.equal( "0123456789ABCDEF0123456789ABCDEF");
-    expect(event.event).to.equal("dialRotate");
+    expect(event.action).to.equal('ts.streamdeck.events.dialRotateTest');
+    expect(event.context).to.equal('FEDCBA9876543210FEDCBA9876543210');
+    expect(event.device).to.equal('0123456789ABCDEF0123456789ABCDEF');
+    expect(event.event).to.equal('dialRotate');
     expect(event.column).to.equal(1);
     expect(event.row).to.equal(0);
-    expect(event.controller).to.equal("Encoder");
+    expect(event.controller).to.equal('Encoder');
     expect(event.pressed).to.be.false;
     expect(event.ticks).to.equal(1);
   });
@@ -35,17 +35,23 @@ describe('DialRotateEvent test', () => {
     const event = new DialRotateEvent(eventValid);
 
     expect(event.settings).to.haveOwnProperty('key');
-    expect((event.settings as {'key': string}).key).to.equal('value');
+    expect((event.settings as { key: string }).key).to.equal('value');
 
     expect(event.settings).to.haveOwnProperty('someNum');
-    expect((event.settings as {'someNum': number}).someNum).to.equal(1234);
+    expect((event.settings as { someNum: number }).someNum).to.equal(1234);
   });
 
   it('should throw a validation error on missing tick parameters', function () {
-    expect(() => new DialRotateEvent(eventMissingParameter)).to.throw(EventValidationError, /required property 'ticks'/);
+    expect(() => new DialRotateEvent(eventMissingParameter)).to.throw(
+      EventValidationError,
+      /required property 'ticks'/,
+    );
   });
 
   it('should throw a validation error on wrong event type', function () {
-    expect(() => new DialRotateEvent(eventInvalidType)).to.throw(EventValidationError, /must match pattern "\^dialRotate\$"/);
+    expect(() => new DialRotateEvent(eventInvalidType)).to.throw(
+      EventValidationError,
+      /must match pattern "\^dialRotate\$"/,
+    );
   });
 });

--- a/test/Events/Received/Plugin/TouchTapEventTest.ts
+++ b/test/Events/Received/Plugin/TouchTapEventTest.ts
@@ -7,19 +7,19 @@ import TouchTapEvent from '@/Events/Received/Plugin/Dial/TouchTapEvent';
 
 import eventInvalidType from '../fixtures/touchTapEvent/invalidEvent.json';
 import eventMissingParameter from '../fixtures/touchTapEvent/missingTapPos.json';
-import eventValid from '../fixtures/touchTapEvent/valid.json';
 import eventValidHold from '../fixtures/touchTapEvent/valid.hold.json';
+import eventValid from '../fixtures/touchTapEvent/valid.json';
 
 describe('TouchTapEvent test', () => {
   it('should handle a normal event', function () {
     const event = new TouchTapEvent(eventValid);
-    expect(event.action).to.equal("ts.streamdeck.events.touchTapTest");
-    expect(event.context).to.equal("FEDCBA9876543210FEDCBA9876543210");
-    expect(event.device).to.equal( "0123456789ABCDEF0123456789ABCDEF");
-    expect(event.event).to.equal("touchTap");
+    expect(event.action).to.equal('ts.streamdeck.events.touchTapTest');
+    expect(event.context).to.equal('FEDCBA9876543210FEDCBA9876543210');
+    expect(event.device).to.equal('0123456789ABCDEF0123456789ABCDEF');
+    expect(event.event).to.equal('touchTap');
     expect(event.column).to.equal(1);
     expect(event.row).to.equal(0);
-    expect(event.controller).to.equal("Encoder");
+    expect(event.controller).to.equal('Encoder');
 
     expect(event.hold).to.be.false;
     expect(event.tapPos.length).to.equal(2);
@@ -37,10 +37,10 @@ describe('TouchTapEvent test', () => {
     const event = new TouchTapEvent(eventValid);
 
     expect(event.settings).to.haveOwnProperty('key');
-    expect((event.settings as {'key': string}).key).to.equal('value');
+    expect((event.settings as { key: string }).key).to.equal('value');
 
     expect(event.settings).to.haveOwnProperty('someNum');
-    expect((event.settings as {'someNum': number}).someNum).to.equal(1234);
+    expect((event.settings as { someNum: number }).someNum).to.equal(1234);
   });
 
   it('should throw a validation error on missing tapPos parameters', function () {
@@ -48,6 +48,9 @@ describe('TouchTapEvent test', () => {
   });
 
   it('should throw a validation error on wrong event type', function () {
-    expect(() => new TouchTapEvent(eventInvalidType)).to.throw(EventValidationError, /must match pattern "\^touchTap\$"/);
+    expect(() => new TouchTapEvent(eventInvalidType)).to.throw(
+      EventValidationError,
+      /must match pattern "\^touchTap\$"/,
+    );
   });
 });

--- a/test/Events/Received/Plugin/TouchTapEventTest.ts
+++ b/test/Events/Received/Plugin/TouchTapEventTest.ts
@@ -1,0 +1,53 @@
+import 'mocha';
+
+import { expect } from 'chai';
+
+import EventValidationError from '@/Events/Received/Exception/EventValidationError';
+import TouchTapEvent from '@/Events/Received/Plugin/Dial/TouchTapEvent';
+
+import eventInvalidType from '../fixtures/touchTapEvent/invalidEvent.json';
+import eventMissingParameter from '../fixtures/touchTapEvent/missingTapPos.json';
+import eventValid from '../fixtures/touchTapEvent/valid.json';
+import eventValidHold from '../fixtures/touchTapEvent/valid.hold.json';
+
+describe('TouchTapEvent test', () => {
+  it('should handle a normal event', function () {
+    const event = new TouchTapEvent(eventValid);
+    expect(event.action).to.equal("ts.streamdeck.events.touchTapTest");
+    expect(event.context).to.equal("FEDCBA9876543210FEDCBA9876543210");
+    expect(event.device).to.equal( "0123456789ABCDEF0123456789ABCDEF");
+    expect(event.event).to.equal("touchTap");
+    expect(event.column).to.equal(1);
+    expect(event.row).to.equal(0);
+    expect(event.controller).to.equal("Encoder");
+
+    expect(event.hold).to.be.false;
+    expect(event.tapPos.length).to.equal(2);
+    expect(event.tapPos[0]).to.equal(37);
+    expect(event.tapPos[1]).to.equal(75);
+  });
+
+  it('should handle a tap hold event', function () {
+    const event = new TouchTapEvent(eventValidHold);
+
+    expect(event.hold).to.be.true;
+  });
+
+  it('should create the event with settings', function () {
+    const event = new TouchTapEvent(eventValid);
+
+    expect(event.settings).to.haveOwnProperty('key');
+    expect((event.settings as {'key': string}).key).to.equal('value');
+
+    expect(event.settings).to.haveOwnProperty('someNum');
+    expect((event.settings as {'someNum': number}).someNum).to.equal(1234);
+  });
+
+  it('should throw a validation error on missing tapPos parameters', function () {
+    expect(() => new TouchTapEvent(eventMissingParameter)).to.throw(EventValidationError, /required property 'tapPos'/);
+  });
+
+  it('should throw a validation error on wrong event type', function () {
+    expect(() => new TouchTapEvent(eventInvalidType)).to.throw(EventValidationError, /must match pattern "\^touchTap\$"/);
+  });
+});

--- a/test/Events/Received/Plugin/WillAppearEventTest.ts
+++ b/test/Events/Received/Plugin/WillAppearEventTest.ts
@@ -3,6 +3,7 @@ import 'mocha';
 import { expect } from 'chai';
 
 import EventValidationError from '@/Events/Received/Exception/EventValidationError';
+import { ControllerType } from '@/Events/Received/Plugin/ControllerType';
 import WillAppearEvent from '@/Events/Received/Plugin/WillAppearEvent';
 
 import eventInvalidType from '../fixtures/willAppearEvent.invalid-eventtype.json';
@@ -11,6 +12,7 @@ import eventValid from '../fixtures/willAppearEvent.valid.json';
 import eventValidMultiAction from '../fixtures/willAppearEvent.valid.multiaction.json';
 import eventValidMultiActionState from '../fixtures/willAppearEvent.valid.multiaction.state.json';
 import eventValidState from '../fixtures/willAppearEvent.valid.state.json';
+import eventValidController from '../fixtures/willAppearEvent.valid.withcontroller.json';
 
 describe('WillAppearEvent test', () => {
   it('should create the event when using the correct payload', function () {
@@ -56,6 +58,14 @@ describe('WillAppearEvent test', () => {
     expect(event.column).to.be.undefined;
     expect(event.row).to.be.undefined;
     expect(Object.keys(event.settings as Record<string, unknown>)).to.be.length(0);
+  });
+  it('should set Controller to Keypad if unset', () => {
+    const event = new WillAppearEvent(eventValid);
+    expect(event.controller).to.equal(ControllerType.Keypad);
+  });
+  it('should set Controller appropriately if set', () => {
+    const event = new WillAppearEvent(eventValidController);
+    expect(event.controller).to.equal(ControllerType.Encoder);
   });
   it('should throw a validation error on missing parameters', function () {
     expect(() => new WillAppearEvent(eventMissingParameter)).to.throw(

--- a/test/Events/Received/fixtures/dialPressEvent/invalidEvent.json
+++ b/test/Events/Received/fixtures/dialPressEvent/invalidEvent.json
@@ -1,0 +1,18 @@
+{
+  "action": "ts.streamdeck.events.dialPressTest",
+  "context": "FEDCBA9876543210FEDCBA9876543210",
+  "device": "0123456789ABCDEF0123456789ABCDEF",
+  "event": "dohnMheg",
+  "payload": {
+    "controller": "Encoder",
+    "coordinates": {
+      "column": 1,
+      "row": 0
+    },
+    "pressed": true,
+    "settings": {
+      "key": "value",
+      "someNum": 1234
+    }
+  }
+}

--- a/test/Events/Received/fixtures/dialPressEvent/missingPressed.json
+++ b/test/Events/Received/fixtures/dialPressEvent/missingPressed.json
@@ -1,0 +1,17 @@
+{
+  "action": "ts.streamdeck.events.dialPressTest",
+  "context": "FEDCBA9876543210FEDCBA9876543210",
+  "device": "0123456789ABCDEF0123456789ABCDEF",
+  "event": "dialPress",
+  "payload": {
+    "controller": "Encoder",
+    "coordinates": {
+      "column": 1,
+      "row": 0
+    },
+    "settings": {
+      "key": "value",
+      "someNum": 1234
+    }
+  }
+}

--- a/test/Events/Received/fixtures/dialPressEvent/valid.dialRelease.json
+++ b/test/Events/Received/fixtures/dialPressEvent/valid.dialRelease.json
@@ -1,0 +1,17 @@
+{
+  "action": "ts.streamdeck.events.dialPressTest",
+  "context": "FEDCBA9876543210FEDCBA9876543210",
+  "device": "0123456789ABCDEF0123456789ABCDEF",
+  "event": "dialPress",
+  "payload": {
+    "controller": "Encoder",
+    "coordinates": {
+      "column": 1,
+      "row": 0
+    },
+    "pressed": false,
+    "settings": {
+      "key": "value"
+    }
+  }
+}

--- a/test/Events/Received/fixtures/dialPressEvent/valid.json
+++ b/test/Events/Received/fixtures/dialPressEvent/valid.json
@@ -1,0 +1,18 @@
+{
+  "action": "ts.streamdeck.events.dialPressTest",
+  "context": "FEDCBA9876543210FEDCBA9876543210",
+  "device": "0123456789ABCDEF0123456789ABCDEF",
+  "event": "dialPress",
+  "payload": {
+    "controller": "Encoder",
+    "coordinates": {
+      "column": 1,
+      "row": 0
+    },
+    "pressed": true,
+    "settings": {
+      "key": "value",
+      "someNum": 1234
+    }
+  }
+}

--- a/test/Events/Received/fixtures/dialRotateEvent/invalidEvent.json
+++ b/test/Events/Received/fixtures/dialRotateEvent/invalidEvent.json
@@ -1,0 +1,19 @@
+{
+  "action": "ts.streamdeck.events.dialRotateTest",
+  "context": "FEDCBA9876543210FEDCBA9876543210",
+  "device": "0123456789ABCDEF0123456789ABCDEF",
+  "event": "qitanaRavel",
+  "payload": {
+    "controller": "Encoder",
+    "coordinates": {
+      "column": 1,
+      "row": 0
+    },
+    "pressed": false,
+    "settings": {
+      "key": "value",
+      "someNum": 1234
+    },
+    "ticks": 1
+  }
+}

--- a/test/Events/Received/fixtures/dialRotateEvent/missingTicks.json
+++ b/test/Events/Received/fixtures/dialRotateEvent/missingTicks.json
@@ -1,0 +1,18 @@
+{
+  "action": "ts.streamdeck.events.dialRotateTest",
+  "context": "FEDCBA9876543210FEDCBA9876543210",
+  "device": "0123456789ABCDEF0123456789ABCDEF",
+  "event": "dialRotate",
+  "payload": {
+    "controller": "Encoder",
+    "coordinates": {
+      "column": 1,
+      "row": 0
+    },
+    "pressed": false,
+    "settings": {
+      "key": "value",
+      "someNum": 1234
+    }
+  }
+}

--- a/test/Events/Received/fixtures/dialRotateEvent/valid.ccw.json
+++ b/test/Events/Received/fixtures/dialRotateEvent/valid.ccw.json
@@ -1,0 +1,19 @@
+{
+  "action": "ts.streamdeck.events.dialRotateTest",
+  "context": "FEDCBA9876543210FEDCBA9876543210",
+  "device": "0123456789ABCDEF0123456789ABCDEF",
+  "event": "dialRotate",
+  "payload": {
+    "controller": "Encoder",
+    "coordinates": {
+      "column": 1,
+      "row": 0
+    },
+    "pressed": true,
+    "settings": {
+      "key": "value",
+      "someNum": 1234
+    },
+    "ticks": -1
+  }
+}

--- a/test/Events/Received/fixtures/dialRotateEvent/valid.json
+++ b/test/Events/Received/fixtures/dialRotateEvent/valid.json
@@ -1,0 +1,19 @@
+{
+  "action": "ts.streamdeck.events.dialRotateTest",
+  "context": "FEDCBA9876543210FEDCBA9876543210",
+  "device": "0123456789ABCDEF0123456789ABCDEF",
+  "event": "dialRotate",
+  "payload": {
+    "controller": "Encoder",
+    "coordinates": {
+      "column": 1,
+      "row": 0
+    },
+    "pressed": false,
+    "settings": {
+      "key": "value",
+      "someNum": 1234
+    },
+    "ticks": 1
+  }
+}

--- a/test/Events/Received/fixtures/touchTapEvent/invalidEvent.json
+++ b/test/Events/Received/fixtures/touchTapEvent/invalidEvent.json
@@ -1,0 +1,19 @@
+{
+  "action": "ts.streamdeck.events.touchTapTest",
+  "context": "FEDCBA9876543210FEDCBA9876543210",
+  "device": "0123456789ABCDEF0123456789ABCDEF",
+  "event": "holminsterSwitch",
+  "payload": {
+    "controller": "Encoder",
+    "coordinates": {
+      "column": 1,
+      "row": 0
+    },
+    "hold": false,
+    "settings": {
+      "key": "value",
+      "someNum": 1234
+    },
+    "tapPos": [ 37, 75 ]
+  }
+}

--- a/test/Events/Received/fixtures/touchTapEvent/missingTapPos.json
+++ b/test/Events/Received/fixtures/touchTapEvent/missingTapPos.json
@@ -1,0 +1,18 @@
+{
+  "action": "ts.streamdeck.events.touchTapTest",
+  "context": "FEDCBA9876543210FEDCBA9876543210",
+  "device": "0123456789ABCDEF0123456789ABCDEF",
+  "event": "touchTap",
+  "payload": {
+    "controller": "Encoder",
+    "coordinates": {
+      "column": 1,
+      "row": 0
+    },
+    "hold": false,
+    "settings": {
+      "key": "value",
+      "someNum": 1234
+    }
+  }
+}

--- a/test/Events/Received/fixtures/touchTapEvent/valid.hold.json
+++ b/test/Events/Received/fixtures/touchTapEvent/valid.hold.json
@@ -1,0 +1,19 @@
+{
+  "action": "ts.streamdeck.events.touchTapTest",
+  "context": "FEDCBA9876543210FEDCBA9876543210",
+  "device": "0123456789ABCDEF0123456789ABCDEF",
+  "event": "touchTap",
+  "payload": {
+    "controller": "Encoder",
+    "coordinates": {
+      "column": 1,
+      "row": 0
+    },
+    "hold": true,
+    "settings": {
+      "key": "value",
+      "someNum": 1234
+    },
+    "tapPos": [ 24, 19 ]
+  }
+}

--- a/test/Events/Received/fixtures/touchTapEvent/valid.json
+++ b/test/Events/Received/fixtures/touchTapEvent/valid.json
@@ -1,0 +1,19 @@
+{
+  "action": "ts.streamdeck.events.touchTapTest",
+  "context": "FEDCBA9876543210FEDCBA9876543210",
+  "device": "0123456789ABCDEF0123456789ABCDEF",
+  "event": "touchTap",
+  "payload": {
+    "controller": "Encoder",
+    "coordinates": {
+      "column": 1,
+      "row": 0
+    },
+    "hold": false,
+    "settings": {
+      "key": "value",
+      "someNum": 1234
+    },
+    "tapPos": [ 37, 75 ]
+  }
+}

--- a/test/Events/Received/fixtures/willAppearEvent.valid.withcontroller.json
+++ b/test/Events/Received/fixtures/willAppearEvent.valid.withcontroller.json
@@ -1,0 +1,15 @@
+{
+  "action": "my.willappear.action",
+  "context": "willappearcontext",
+  "device": "dev",
+  "event": "willAppear",
+  "payload": {
+    "controller": "Encoder",
+    "coordinates": {
+      "column": 1,
+      "row": 0
+    },
+    "isInMultiAction": false,
+    "settings": {}
+  }
+}

--- a/test/Events/Sent/Plugin/SetFeedbackEvent.ts
+++ b/test/Events/Sent/Plugin/SetFeedbackEvent.ts
@@ -21,10 +21,26 @@ describe('SetFeedbackEvent test', () => {
     const event = new SetFeedbackEvent(payload, 'context');
     expect(JSON.parse(JSON.stringify(event))).to.be.jsonSchema(SetFeedbackType);
   });
+
   it('returns the right values for a basic event', () => {
     const event = new SetFeedbackEvent(payload, 'context');
     expect(JSON.parse(JSON.stringify(event)).payload.value.value).to.equal('123');
     expect(JSON.parse(JSON.stringify(event)).payload.value.enabled).to.be.true;
     expect(JSON.parse(JSON.stringify(event)).payload.value.color).to.equal('green');
   });
+
+  it('returns the right values on a custom layout', () => {
+    const event = new SetFeedbackEvent({
+      title: 'Dun Scaith',
+      mxProgress: {
+        value: 80,
+        bar_fill_c: "#ffff00"
+      }
+    }, 'context');
+
+    let transmutedEvent = JSON.parse(JSON.stringify(event));
+    expect(transmutedEvent.payload.title).to.equal('Dun Scaith');
+    expect(transmutedEvent.payload.mxProgress.value).to.equal(80);
+    expect(transmutedEvent.payload.mxProgress.bar_fill_c).to.equal('#ffff00');
+  })
 });

--- a/test/Events/Sent/Plugin/SetFeedbackEvent.ts
+++ b/test/Events/Sent/Plugin/SetFeedbackEvent.ts
@@ -1,0 +1,30 @@
+import 'mocha';
+
+import { expect, use } from 'chai';
+import jsonschema from 'chai-json-schema';
+
+import {SetFeedbackEvent} from '@/Events/Sent/Plugin';
+import {SetFeedbackType} from "@/StreamdeckTypes/Received/SetFeedbackType";
+
+use(jsonschema);
+
+describe('SetFeedbackEvent test', () => {
+  const payload = {
+    "value": {
+      "value": "123",
+      "enabled": true,
+      "color": "green"
+    }
+  }
+
+  it('validates a basic feedback layout against the json schema', () => {
+    const event = new SetFeedbackEvent(payload, 'context');
+    expect(JSON.parse(JSON.stringify(event))).to.be.jsonSchema(SetFeedbackType);
+  });
+  it('returns the right values for a basic event', () => {
+    const event = new SetFeedbackEvent(payload, 'context');
+    expect(JSON.parse(JSON.stringify(event)).payload.value.value).to.equal('123');
+    expect(JSON.parse(JSON.stringify(event)).payload.value.enabled).to.be.true;
+    expect(JSON.parse(JSON.stringify(event)).payload.value.color).to.equal('green');
+  });
+});

--- a/test/Events/Sent/Plugin/SetFeedbackEvent.ts
+++ b/test/Events/Sent/Plugin/SetFeedbackEvent.ts
@@ -30,17 +30,18 @@ describe('SetFeedbackEvent test', () => {
   });
 
   it('returns the right values on a custom layout', () => {
-    const event = new SetFeedbackEvent({
-      title: 'Dun Scaith',
+    const payload = {
       mxProgress: {
+        bar_fill_c: '#ffff00',
         value: 80,
-        bar_fill_c: "#ffff00"
-      }
-    }, 'context');
+      },
+      title: 'Dun Scaith',
+    };
+    const event = new SetFeedbackEvent(payload, 'context');
 
-    let transmutedEvent = JSON.parse(JSON.stringify(event));
+    const transmutedEvent = JSON.parse(JSON.stringify(event));
     expect(transmutedEvent.payload.title).to.equal('Dun Scaith');
     expect(transmutedEvent.payload.mxProgress.value).to.equal(80);
     expect(transmutedEvent.payload.mxProgress.bar_fill_c).to.equal('#ffff00');
-  })
+  });
 });

--- a/test/Events/Sent/Plugin/SetFeedbackEvent.ts
+++ b/test/Events/Sent/Plugin/SetFeedbackEvent.ts
@@ -3,19 +3,19 @@ import 'mocha';
 import { expect, use } from 'chai';
 import jsonschema from 'chai-json-schema';
 
-import {SetFeedbackEvent} from '@/Events/Sent/Plugin';
-import {SetFeedbackType} from "@/StreamdeckTypes/Received/SetFeedbackType";
+import { SetFeedbackEvent } from '@/Events/Sent/Plugin';
+import { SetFeedbackType } from '@/StreamdeckTypes/Received/SetFeedbackType';
 
 use(jsonschema);
 
 describe('SetFeedbackEvent test', () => {
   const payload = {
-    "value": {
-      "value": "123",
-      "enabled": true,
-      "color": "green"
-    }
-  }
+    value: {
+      color: 'green',
+      enabled: true,
+      value: '123',
+    },
+  };
 
   it('validates a basic feedback layout against the json schema', () => {
     const event = new SetFeedbackEvent(payload, 'context');

--- a/test/Events/Sent/Plugin/SetFeedbackLayoutEventTest.ts
+++ b/test/Events/Sent/Plugin/SetFeedbackLayoutEventTest.ts
@@ -1,0 +1,20 @@
+import 'mocha';
+
+import { expect, use } from 'chai';
+import jsonschema from 'chai-json-schema';
+
+import {SetFeedbackLayoutEvent} from '@/Events/Sent/Plugin';
+import {SetFeedbackLayoutType} from "@/StreamdeckTypes/Received/SetFeedbackLayoutType";
+
+use(jsonschema);
+
+describe('SetFeedbackLayoutEvent test', () => {
+  it('validates a basic feedback layout against the json schema', () => {
+    const event = new SetFeedbackLayoutEvent('$A0', 'context');
+    expect(JSON.parse(JSON.stringify(event))).to.be.jsonSchema(SetFeedbackLayoutType);
+  });
+  it('returns the right values for a basic event', () => {
+    const event = new SetFeedbackLayoutEvent('$B1', 'context');
+    expect(JSON.parse(JSON.stringify(event)).payload.layout).to.equal('$B1');
+  });
+});

--- a/test/Events/Sent/Plugin/SetFeedbackLayoutEventTest.ts
+++ b/test/Events/Sent/Plugin/SetFeedbackLayoutEventTest.ts
@@ -3,8 +3,8 @@ import 'mocha';
 import { expect, use } from 'chai';
 import jsonschema from 'chai-json-schema';
 
-import {SetFeedbackLayoutEvent} from '@/Events/Sent/Plugin';
-import {SetFeedbackLayoutType} from "@/StreamdeckTypes/Received/SetFeedbackLayoutType";
+import { SetFeedbackLayoutEvent } from '@/Events/Sent/Plugin';
+import { SetFeedbackLayoutType } from '@/StreamdeckTypes/Received/SetFeedbackLayoutType';
 
 use(jsonschema);
 

--- a/test/Events/Sent/Plugin/SetFeedbackLayoutEventTest.ts
+++ b/test/Events/Sent/Plugin/SetFeedbackLayoutEventTest.ts
@@ -17,4 +17,9 @@ describe('SetFeedbackLayoutEvent test', () => {
     const event = new SetFeedbackLayoutEvent('$B1', 'context');
     expect(JSON.parse(JSON.stringify(event)).payload.layout).to.equal('$B1');
   });
+
+  it('returns the right values for a custom layout', () => {
+    const event = new SetFeedbackLayoutEvent('layouts/progress.json', 'context');
+    expect(JSON.parse(JSON.stringify(event)).payload.layout).to.equal('layouts/progress.json');
+  })
 });

--- a/test/Events/Sent/Plugin/SetFeedbackLayoutEventTest.ts
+++ b/test/Events/Sent/Plugin/SetFeedbackLayoutEventTest.ts
@@ -21,5 +21,5 @@ describe('SetFeedbackLayoutEvent test', () => {
   it('returns the right values for a custom layout', () => {
     const event = new SetFeedbackLayoutEvent('layouts/progress.json', 'context');
     expect(JSON.parse(JSON.stringify(event)).payload.layout).to.equal('layouts/progress.json');
-  })
+  });
 });

--- a/test/Events/Streamdeck/Received/EventFactoryTest.ts
+++ b/test/Events/Streamdeck/Received/EventFactoryTest.ts
@@ -82,15 +82,11 @@ describe('EventFactory test', () => {
   });
 
   it('should return a SetFeedbackEvent', () => {
-    expect(new EventFactory().createByEventPayload(eventSetFeedback)).to.be.instanceof(
-      SetFeedbackEvent
-    );
+    expect(new EventFactory().createByEventPayload(eventSetFeedback)).to.be.instanceof(SetFeedbackEvent);
   });
 
   it('should return a SetFeedbackLayoutEvent', () => {
-    expect(new EventFactory().createByEventPayload(eventSetFeedbackLayout)).to.be.instanceOf(
-      SetFeedbackLayoutEvent
-    )
+    expect(new EventFactory().createByEventPayload(eventSetFeedbackLayout)).to.be.instanceOf(SetFeedbackLayoutEvent);
   });
 
   it('should return a SetGlobalSettingsEvent', () => {

--- a/test/Events/Streamdeck/Received/EventFactoryTest.ts
+++ b/test/Events/Streamdeck/Received/EventFactoryTest.ts
@@ -11,6 +11,8 @@ import {
   RegisterEvent,
   SendToPluginEvent,
   SendToPropertyInspectorEvent,
+  SetFeedbackEvent,
+  SetFeedbackLayoutEvent,
   SetGlobalSettingsEvent,
   SetImageEvent,
   SetSettingsEvent,
@@ -28,6 +30,8 @@ import eventOpenUrl from './fixtures/openUrlEvent.valid.json';
 import eventRegister from './fixtures/registerEvent.valid.json';
 import eventSendToPlugin from './fixtures/sendToPluginEvent.valid.json';
 import eventSendToPropertyInspector from './fixtures/sendToPropertyInspectorEvent.valid.json';
+import eventSetFeedback from './fixtures/setFeedback/valid.json';
+import eventSetFeedbackLayout from './fixtures/setFeedbackLayout/valid.json';
 import eventSetGlobalSettings from './fixtures/setGlobalSettingsEvent.valid.json';
 import eventSetImage from './fixtures/setImageEvent.valid.json';
 import eventSetSettings from './fixtures/setSettingsEvent.valid.json';
@@ -75,6 +79,18 @@ describe('EventFactory test', () => {
     expect(new EventFactory().createByEventPayload(eventSendToPropertyInspector)).to.be.instanceOf(
       SendToPropertyInspectorEvent,
     );
+  });
+
+  it('should return a SetFeedbackEvent', () => {
+    expect(new EventFactory().createByEventPayload(eventSetFeedback)).to.be.instanceof(
+      SetFeedbackEvent
+    );
+  });
+
+  it('should return a SetFeedbackLayoutEvent', () => {
+    expect(new EventFactory().createByEventPayload(eventSetFeedbackLayout)).to.be.instanceOf(
+      SetFeedbackLayoutEvent
+    )
   });
 
   it('should return a SetGlobalSettingsEvent', () => {

--- a/test/Events/Streamdeck/Received/SetFeedbackEventTest.ts
+++ b/test/Events/Streamdeck/Received/SetFeedbackEventTest.ts
@@ -3,9 +3,9 @@ import { expect } from 'chai';
 import EventValidationError from '@/Events/Received/Exception/EventValidationError';
 import { SetFeedbackEvent } from '@/Events/Streamdeck/Received';
 
-import eventInvalidType from './fixtures/setFeedback/wrongEvent.json';
 import eventMissingParameter from './fixtures/setFeedback/missingPayload.json';
 import eventValid from './fixtures/setFeedback/valid.json';
+import eventInvalidType from './fixtures/setFeedback/wrongEvent.json';
 
 describe('SetFeedbackEvent Test', () => {
   it('should create the event when using the correct payload', function () {
@@ -14,11 +14,14 @@ describe('SetFeedbackEvent Test', () => {
     expect(event.context).to.equal('FEDCBA9876543210FEDCBA9876543210');
 
     expect(event.payload).to.haveOwnProperty('value');
-    expect((event.payload as {'value': number}).value).to.equal("0%");
+    expect((event.payload as { value: number }).value).to.equal('0%');
   });
 
   it('should throw a validation error on missing parameters', function () {
-    expect(() => new SetFeedbackEvent(eventMissingParameter)).to.throw(EventValidationError, /required property 'payload'/);
+    expect(() => new SetFeedbackEvent(eventMissingParameter)).to.throw(
+      EventValidationError,
+      /required property 'payload'/,
+    );
   });
 
   it('should throw a validation error on wrong event type', function () {

--- a/test/Events/Streamdeck/Received/SetFeedbackEventTest.ts
+++ b/test/Events/Streamdeck/Received/SetFeedbackEventTest.ts
@@ -2,32 +2,53 @@ import { expect } from 'chai';
 
 import EventValidationError from '@/Events/Received/Exception/EventValidationError';
 import { SetFeedbackEvent } from '@/Events/Streamdeck/Received';
+import { BarFeedbackComponent } from "@/StreamdeckTypes/Received/Feedback/Components";
+
 
 import eventMissingParameter from './fixtures/setFeedback/missingPayload.json';
 import eventValid from './fixtures/setFeedback/valid.json';
+import eventCustom from './fixtures/setFeedback/custom.json';
 import eventInvalidType from './fixtures/setFeedback/wrongEvent.json';
+import eventInvalidTitle from './fixtures/setFeedback/badTitle.json';
 
 describe('SetFeedbackEvent Test', () => {
-  it('should create the event when using the correct payload', function () {
+  it('should create the event when using the correct payload', () => {
     const event = new SetFeedbackEvent(eventValid);
     expect(event.event).to.equal('setFeedback');
     expect(event.context).to.equal('FEDCBA9876543210FEDCBA9876543210');
 
     expect(event.payload).to.haveOwnProperty('value');
-    expect((event.payload as { value: number }).value).to.equal('0%');
+    expect((event.payload).value).to.equal('0%');
   });
 
-  it('should throw a validation error on missing parameters', function () {
+  it('should create an event with keys for a custom layout in the payload', () => {
+    const event = new SetFeedbackEvent(eventCustom);
+
+    expect(event.payload).to.haveOwnProperty('mxProgress');
+
+    let mxProgressElement = event.payload.mxProgress as BarFeedbackComponent;
+    expect(mxProgressElement.bar_bg_c).to.equal('#FFFF00');
+    expect(mxProgressElement.value).to.equal(40);
+  })
+
+  it('should throw a validation error on missing parameters', () => {
     expect(() => new SetFeedbackEvent(eventMissingParameter)).to.throw(
       EventValidationError,
       /required property 'payload'/,
     );
   });
 
-  it('should throw a validation error on wrong event type', function () {
+  it('should throw a validation error on wrong event type', () => {
     expect(() => new SetFeedbackEvent(eventInvalidType)).to.throw(
       EventValidationError,
       /must match pattern "\^setFeedback\$"/,
     );
   });
+
+  it('should throw a validation error on a malformed title', () => {
+    expect(() => new SetFeedbackEvent(eventInvalidTitle)).to.throw(
+      EventValidationError,
+      /must have required property 'value'/
+    )
+  })
 });

--- a/test/Events/Streamdeck/Received/SetFeedbackEventTest.ts
+++ b/test/Events/Streamdeck/Received/SetFeedbackEventTest.ts
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+
+import EventValidationError from '@/Events/Received/Exception/EventValidationError';
+import { SetFeedbackEvent } from '@/Events/Streamdeck/Received';
+
+import eventInvalidType from './fixtures/setFeedback/wrongEvent.json';
+import eventMissingParameter from './fixtures/setFeedback/missingPayload.json';
+import eventValid from './fixtures/setFeedback/valid.json';
+
+describe('SetFeedbackEvent Test', () => {
+  it('should create the event when using the correct payload', function () {
+    const event = new SetFeedbackEvent(eventValid);
+    expect(event.event).to.equal('setFeedback');
+    expect(event.context).to.equal('FEDCBA9876543210FEDCBA9876543210');
+
+    expect(event.payload).to.haveOwnProperty('value');
+    expect((event.payload as {'value': number}).value).to.equal("0%");
+  });
+
+  it('should throw a validation error on missing parameters', function () {
+    expect(() => new SetFeedbackEvent(eventMissingParameter)).to.throw(EventValidationError, /required property 'payload'/);
+  });
+
+  it('should throw a validation error on wrong event type', function () {
+    expect(() => new SetFeedbackEvent(eventInvalidType)).to.throw(
+      EventValidationError,
+      /must match pattern "\^setFeedback\$"/,
+    );
+  });
+});

--- a/test/Events/Streamdeck/Received/SetFeedbackEventTest.ts
+++ b/test/Events/Streamdeck/Received/SetFeedbackEventTest.ts
@@ -2,14 +2,13 @@ import { expect } from 'chai';
 
 import EventValidationError from '@/Events/Received/Exception/EventValidationError';
 import { SetFeedbackEvent } from '@/Events/Streamdeck/Received';
-import { BarFeedbackComponent } from "@/StreamdeckTypes/Received/Feedback/Components";
+import { BarFeedbackComponent } from '@/StreamdeckTypes/Received/Feedback/Components';
 
-
+import eventInvalidTitle from './fixtures/setFeedback/badTitle.json';
+import eventCustom from './fixtures/setFeedback/custom.json';
 import eventMissingParameter from './fixtures/setFeedback/missingPayload.json';
 import eventValid from './fixtures/setFeedback/valid.json';
-import eventCustom from './fixtures/setFeedback/custom.json';
 import eventInvalidType from './fixtures/setFeedback/wrongEvent.json';
-import eventInvalidTitle from './fixtures/setFeedback/badTitle.json';
 
 describe('SetFeedbackEvent Test', () => {
   it('should create the event when using the correct payload', () => {
@@ -18,7 +17,7 @@ describe('SetFeedbackEvent Test', () => {
     expect(event.context).to.equal('FEDCBA9876543210FEDCBA9876543210');
 
     expect(event.payload).to.haveOwnProperty('value');
-    expect((event.payload).value).to.equal('0%');
+    expect(event.payload.value).to.equal('0%');
   });
 
   it('should create an event with keys for a custom layout in the payload', () => {
@@ -26,10 +25,10 @@ describe('SetFeedbackEvent Test', () => {
 
     expect(event.payload).to.haveOwnProperty('mxProgress');
 
-    let mxProgressElement = event.payload.mxProgress as BarFeedbackComponent;
+    const mxProgressElement = event.payload.mxProgress as BarFeedbackComponent;
     expect(mxProgressElement.bar_bg_c).to.equal('#FFFF00');
     expect(mxProgressElement.value).to.equal(40);
-  })
+  });
 
   it('should throw a validation error on missing parameters', () => {
     expect(() => new SetFeedbackEvent(eventMissingParameter)).to.throw(
@@ -48,7 +47,7 @@ describe('SetFeedbackEvent Test', () => {
   it('should throw a validation error on a malformed title', () => {
     expect(() => new SetFeedbackEvent(eventInvalidTitle)).to.throw(
       EventValidationError,
-      /must have required property 'value'/
-    )
-  })
+      /must have required property 'value'/,
+    );
+  });
 });

--- a/test/Events/Streamdeck/Received/SetFeedbackLayoutEventTest.ts
+++ b/test/Events/Streamdeck/Received/SetFeedbackLayoutEventTest.ts
@@ -5,10 +5,11 @@ import { SetFeedbackLayoutEvent } from '@/Events/Streamdeck/Received';
 
 import eventMissingParameter from './fixtures/setFeedbackLayout/missingLayout.json';
 import eventValid from './fixtures/setFeedbackLayout/valid.json';
+import eventCustom from './fixtures/setFeedbackLayout/custom.json';
 import eventInvalidType from './fixtures/setFeedbackLayout/wrongEvent.json';
 
 describe('SetFeedbackLayoutEvent Test', () => {
-  it('should create the event when using the correct payload', function () {
+  it('should create the event when using the correct payload', () => {
     const event = new SetFeedbackLayoutEvent(eventValid);
     expect(event.event).to.equal('setFeedbackLayout');
     expect(event.context).to.equal('FEDCBA9876543210FEDCBA9876543210');
@@ -16,14 +17,19 @@ describe('SetFeedbackLayoutEvent Test', () => {
     expect(event.layout).to.equal('$B1');
   });
 
-  it('should throw a validation error on missing parameters', function () {
+  it('should create the event with a custom layout in the payload', () => {
+    const event = new SetFeedbackLayoutEvent(eventCustom);
+    expect(event.layout).to.equal('layouts/progress/progressv2.json');
+  })
+
+  it('should throw a validation error on missing parameters', () => {
     expect(() => new SetFeedbackLayoutEvent(eventMissingParameter)).to.throw(
       EventValidationError,
       /required property 'layout'/,
     );
   });
 
-  it('should throw a validation error on wrong event type', function () {
+  it('should throw a validation error on wrong event type', () => {
     expect(() => new SetFeedbackLayoutEvent(eventInvalidType)).to.throw(
       EventValidationError,
       /must match pattern "\^setFeedbackLayout\$"/,

--- a/test/Events/Streamdeck/Received/SetFeedbackLayoutEventTest.ts
+++ b/test/Events/Streamdeck/Received/SetFeedbackLayoutEventTest.ts
@@ -3,9 +3,9 @@ import { expect } from 'chai';
 import EventValidationError from '@/Events/Received/Exception/EventValidationError';
 import { SetFeedbackLayoutEvent } from '@/Events/Streamdeck/Received';
 
-import eventInvalidType from './fixtures/setFeedbackLayout/wrongEvent.json';
 import eventMissingParameter from './fixtures/setFeedbackLayout/missingLayout.json';
 import eventValid from './fixtures/setFeedbackLayout/valid.json';
+import eventInvalidType from './fixtures/setFeedbackLayout/wrongEvent.json';
 
 describe('SetFeedbackLayoutEvent Test', () => {
   it('should create the event when using the correct payload', function () {
@@ -13,11 +13,14 @@ describe('SetFeedbackLayoutEvent Test', () => {
     expect(event.event).to.equal('setFeedbackLayout');
     expect(event.context).to.equal('FEDCBA9876543210FEDCBA9876543210');
 
-    expect(event.layout).to.equal("$B1");
+    expect(event.layout).to.equal('$B1');
   });
 
   it('should throw a validation error on missing parameters', function () {
-    expect(() => new SetFeedbackLayoutEvent(eventMissingParameter)).to.throw(EventValidationError, /required property 'layout'/);
+    expect(() => new SetFeedbackLayoutEvent(eventMissingParameter)).to.throw(
+      EventValidationError,
+      /required property 'layout'/,
+    );
   });
 
   it('should throw a validation error on wrong event type', function () {

--- a/test/Events/Streamdeck/Received/SetFeedbackLayoutEventTest.ts
+++ b/test/Events/Streamdeck/Received/SetFeedbackLayoutEventTest.ts
@@ -3,9 +3,9 @@ import { expect } from 'chai';
 import EventValidationError from '@/Events/Received/Exception/EventValidationError';
 import { SetFeedbackLayoutEvent } from '@/Events/Streamdeck/Received';
 
+import eventCustom from './fixtures/setFeedbackLayout/custom.json';
 import eventMissingParameter from './fixtures/setFeedbackLayout/missingLayout.json';
 import eventValid from './fixtures/setFeedbackLayout/valid.json';
-import eventCustom from './fixtures/setFeedbackLayout/custom.json';
 import eventInvalidType from './fixtures/setFeedbackLayout/wrongEvent.json';
 
 describe('SetFeedbackLayoutEvent Test', () => {
@@ -20,7 +20,7 @@ describe('SetFeedbackLayoutEvent Test', () => {
   it('should create the event with a custom layout in the payload', () => {
     const event = new SetFeedbackLayoutEvent(eventCustom);
     expect(event.layout).to.equal('layouts/progress/progressv2.json');
-  })
+  });
 
   it('should throw a validation error on missing parameters', () => {
     expect(() => new SetFeedbackLayoutEvent(eventMissingParameter)).to.throw(

--- a/test/Events/Streamdeck/Received/SetFeedbackLayoutEventTest.ts
+++ b/test/Events/Streamdeck/Received/SetFeedbackLayoutEventTest.ts
@@ -1,0 +1,29 @@
+import { expect } from 'chai';
+
+import EventValidationError from '@/Events/Received/Exception/EventValidationError';
+import { SetFeedbackLayoutEvent } from '@/Events/Streamdeck/Received';
+
+import eventInvalidType from './fixtures/setFeedbackLayout/wrongEvent.json';
+import eventMissingParameter from './fixtures/setFeedbackLayout/missingLayout.json';
+import eventValid from './fixtures/setFeedbackLayout/valid.json';
+
+describe('SetFeedbackLayoutEvent Test', () => {
+  it('should create the event when using the correct payload', function () {
+    const event = new SetFeedbackLayoutEvent(eventValid);
+    expect(event.event).to.equal('setFeedbackLayout');
+    expect(event.context).to.equal('FEDCBA9876543210FEDCBA9876543210');
+
+    expect(event.layout).to.equal("$B1");
+  });
+
+  it('should throw a validation error on missing parameters', function () {
+    expect(() => new SetFeedbackLayoutEvent(eventMissingParameter)).to.throw(EventValidationError, /required property 'layout'/);
+  });
+
+  it('should throw a validation error on wrong event type', function () {
+    expect(() => new SetFeedbackLayoutEvent(eventInvalidType)).to.throw(
+      EventValidationError,
+      /must match pattern "\^setFeedbackLayout\$"/,
+    );
+  });
+});

--- a/test/Events/Streamdeck/Received/fixtures/setFeedback/badTitle.json
+++ b/test/Events/Streamdeck/Received/fixtures/setFeedback/badTitle.json
@@ -1,0 +1,10 @@
+{
+  "context": "FEDCBA9876543210FEDCBA9876543210",
+  "event": "setFeedback",
+  "payload": {
+    "value": "Miqo'te",
+    "title": {
+      "pantheon": "Thaliak"
+    }
+  }
+}

--- a/test/Events/Streamdeck/Received/fixtures/setFeedback/custom.json
+++ b/test/Events/Streamdeck/Received/fixtures/setFeedback/custom.json
@@ -1,0 +1,11 @@
+{
+  "context": "FEDCBA9876543210FEDCBA9876543210",
+  "event": "setFeedback",
+  "payload": {
+    "mxProgress": {
+      "value": 40,
+      "bar_bg_c": "#FFFF00"
+    },
+    "value": "0%"
+  }
+}

--- a/test/Events/Streamdeck/Received/fixtures/setFeedback/missingPayload.json
+++ b/test/Events/Streamdeck/Received/fixtures/setFeedback/missingPayload.json
@@ -1,0 +1,4 @@
+{
+  "context": "FEDCBA9876543210FEDCBA9876543210",
+  "event": "setFeedback"
+}

--- a/test/Events/Streamdeck/Received/fixtures/setFeedback/valid.json
+++ b/test/Events/Streamdeck/Received/fixtures/setFeedback/valid.json
@@ -1,0 +1,12 @@
+{
+  "context": "FEDCBA9876543210FEDCBA9876543210",
+  "event": "setFeedback",
+  "payload": {
+    "indicator": {
+      "value": 0,
+      "opacity": 1,
+      "enabled": true
+    },
+    "value": "0%"
+  }
+}

--- a/test/Events/Streamdeck/Received/fixtures/setFeedback/wrongEvent.json
+++ b/test/Events/Streamdeck/Received/fixtures/setFeedback/wrongEvent.json
@@ -1,0 +1,12 @@
+{
+  "context": "FEDCBA9876543210FEDCBA9876543210",
+  "event": "mtGulg",
+  "payload": {
+    "indicator": {
+      "value": 0,
+      "opacity": 1,
+      "enabled": true
+    },
+    "value": "0%"
+  }
+}

--- a/test/Events/Streamdeck/Received/fixtures/setFeedbackLayout/custom.json
+++ b/test/Events/Streamdeck/Received/fixtures/setFeedbackLayout/custom.json
@@ -1,0 +1,7 @@
+{
+  "context": "FEDCBA9876543210FEDCBA9876543210",
+  "event": "setFeedbackLayout",
+  "payload": {
+    "layout": "layouts/progress/progressv2.json"
+  }
+}

--- a/test/Events/Streamdeck/Received/fixtures/setFeedbackLayout/missingLayout.json
+++ b/test/Events/Streamdeck/Received/fixtures/setFeedbackLayout/missingLayout.json
@@ -1,0 +1,5 @@
+{
+  "context": "FEDCBA9876543210FEDCBA9876543210",
+  "event": "setFeedbackLayout",
+  "payload": {}
+}

--- a/test/Events/Streamdeck/Received/fixtures/setFeedbackLayout/valid.json
+++ b/test/Events/Streamdeck/Received/fixtures/setFeedbackLayout/valid.json
@@ -1,0 +1,7 @@
+{
+  "context": "FEDCBA9876543210FEDCBA9876543210",
+  "event": "setFeedbackLayout",
+  "payload": {
+    "layout": "$B1"
+  }
+}

--- a/test/Events/Streamdeck/Received/fixtures/setFeedbackLayout/wrongEvent.json
+++ b/test/Events/Streamdeck/Received/fixtures/setFeedbackLayout/wrongEvent.json
@@ -1,0 +1,7 @@
+{
+  "context": "FEDCBA9876543210FEDCBA9876543210",
+  "event": "theGrandCosmos",
+  "payload": {
+    "layout": "$B1"
+  }
+}

--- a/test/Events/Streamdeck/Sent/WillAppearEventTest.ts
+++ b/test/Events/Streamdeck/Sent/WillAppearEventTest.ts
@@ -3,6 +3,7 @@ import 'mocha';
 import { expect, use } from 'chai';
 import jsonschema from 'chai-json-schema';
 
+import { ControllerType } from '@/Events/Received/Plugin/ControllerType';
 import { WillAppearEvent } from '@/Events/Streamdeck/Sent';
 import { WillAppearType } from '@/StreamdeckTypes/Sent';
 
@@ -22,10 +23,12 @@ describe('WillAppearEvent test', () => {
     expect(parse.payload.coordinates?.column).to.equal(1);
     expect(parse.payload.coordinates?.row).to.equal(1);
     expect(parse.payload.isInMultiAction).to.be.false;
+    expect(parse.payload.controller).to.be.equal('Keypad');
   });
   it('returns the right values for the changed options', () => {
     const event = new WillAppearEvent('action312', 'context312', {
       column: 3,
+      controller: ControllerType.Encoder,
       device: 'lala',
       isInMultiAction: true,
       row: 4,
@@ -37,5 +40,6 @@ describe('WillAppearEvent test', () => {
     expect(parse.payload.isInMultiAction).to.be.true;
     expect((parse.payload.settings as Record<string, boolean>).foo).to.be.true;
     expect((parse.payload.settings as Record<string, string>).bar).to.equal('baz');
+    expect(parse.payload.controller).to.equal('Encoder');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -900,10 +900,10 @@
     lodash "^4.17.4"
     read-pkg-up "^7.0.0"
 
-"@sinclair/typebox@0.24.48":
-  version "0.24.48"
-  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.48.tgz#bd558c6059df563d49a4d94df8e8e0510b662e3f"
-  integrity sha512-WPGpRNHbkOsfBDmh8QHU7a5NWzEuYNThST8x1cISvX0RpP+1+V8zjuJqNwGJkHGIlhdIIhv6qVYqXz2q5/gjAA==
+"@sinclair/typebox@0.24.49":
+  version "0.24.49"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.49.tgz#7a3a5569fe9e4faa47d8019246d37541c2d7a058"
+  integrity sha512-qWgJVeCThMWTJSAZHyHDlHBkJY0LARFoq/96RH4oIFAwJptMwB3Isq62c4zRVRIAF2r4RMOc2WOhtOLj5C4InA==
 
 "@tootallnate/once@2":
   version "2.0.0"


### PR DESCRIPTION
As Elgato has released the Stream Deck+ (and, frustratingly, has yet to release any documentation), I've been exploring the API and using the implementations of Elgato's provided plugins to attempt to create my own API docs. This pull request is the result of the initial pass of discoveries, and is unofficial pending documentation. All (valid) events are anonymized and simplified versions of those captured going to/from the websockets, and should hopefully be accurate. ***I am still working on testing this PR, so it should be considered a draft.*** As I'm also new to working with this project at a code level, I'm sure there are quite a few things I missed in various places that will need to be updated as well, my apologies for this!

While I don't fully expect this PR to be merged, I *do* hope that it will at least provide a reference implementation for future work to build on. This PR *should*, however, allow plugin developers to hopefully immediately start using the `streamdeck-ts` library to deliver experiences using the Stream Deck+.

The `setFeedback` API is still *woefully* under-documented, as it's rather all over the place and a bit confusing - if you're interested in getting a copy of my work so far (or helping me blend it into this project), please let me know and I'll be more than happy to contribute that information. I will additionally be adding some notes as a code review to this PR as well, in the hopes that it's useful.

Thank you for the library!