### PR TITLE
Stream Deck SDK 6.1 Changes

### DIFF
--- a/src/Events/Received/EventFactory.ts
+++ b/src/Events/Received/EventFactory.ts
@@ -10,8 +10,10 @@ import {
   ApplicationDidTerminateEvent,
   DeviceDidConnectEvent,
   DeviceDidDisconnectEvent,
+  DialDownEvent,
   DialPressEvent,
   DialRotateEvent,
+  DialUpEvent,
   KeyDownEvent,
   KeyUpEvent,
   PropertyInspectorDidAppearEvent,
@@ -51,10 +53,14 @@ export default class EventFactory {
         return new DeviceDidConnectEvent(payload);
       case 'deviceDidDisconnect':
         return new DeviceDidDisconnectEvent(payload);
+      case 'dialDown':
+        return new DialDownEvent(payload);
       case 'dialPress':
         return new DialPressEvent(payload);
       case 'dialRotate':
         return new DialRotateEvent(payload);
+      case 'dialUp':
+        return new DialUpEvent(payload);
       case 'didReceiveSettings':
         return new DidReceiveSettingsEvent(payload);
       case 'didReceiveGlobalSettings':

--- a/src/Events/Received/Plugin/Dial/DialDownEvent.ts
+++ b/src/Events/Received/Plugin/Dial/DialDownEvent.ts
@@ -1,0 +1,14 @@
+import AbstractEncoderEvent from '@/Events/Received/Plugin/Dial/AbstractEncoderEvent';
+import { DialDownEventType } from '@/StreamdeckTypes/Sent/Dial';
+
+/**
+ * An event fired when the user presses a dial on their Stream Deck.
+ * Present in Stream Deck SDK version 6.1 and higher.
+ */
+export default class DialDownEvent extends AbstractEncoderEvent {
+  public readonly event = 'dialDown';
+
+  protected get validationType(): typeof DialDownEventType {
+    return DialDownEventType;
+  }
+}

--- a/src/Events/Received/Plugin/Dial/DialPressEvent.ts
+++ b/src/Events/Received/Plugin/Dial/DialPressEvent.ts
@@ -5,6 +5,9 @@ import { DialPressEventType } from '@/StreamdeckTypes/Sent/Dial';
  * An event fired when the user presses or releases a dial on their Stream Deck.
  *
  * In order to determine if this was a press or release event, check the result of {@linkcode pressed}.
+ *
+ * @deprecated The `dialPress` event was deprecated in Stream Deck SDK 6.1, and will be removed in a future version. It
+ * has been replaced by the `dialDown` and `dialUp` events.
  */
 export default class DialPressEvent extends AbstractEncoderEvent {
   public readonly event = 'dialPress';

--- a/src/Events/Received/Plugin/Dial/DialUpEvent.ts
+++ b/src/Events/Received/Plugin/Dial/DialUpEvent.ts
@@ -1,0 +1,14 @@
+import AbstractEncoderEvent from '@/Events/Received/Plugin/Dial/AbstractEncoderEvent';
+import { DialUpEventType } from '@/StreamdeckTypes/Sent/Dial';
+
+/**
+ * An event fired when the user releases a dial on their Stream Deck.
+ * Present in Stream Deck SDK version 6.1 and higher.
+ */
+export default class DialUpEvent extends AbstractEncoderEvent {
+  public readonly event = 'dialUp';
+
+  protected get validationType(): typeof DialUpEventType {
+    return DialUpEventType;
+  }
+}

--- a/src/Events/Received/Plugin/Dial/index.ts
+++ b/src/Events/Received/Plugin/Dial/index.ts
@@ -1,3 +1,5 @@
+export { default as DialDownEvent } from './DialDownEvent';
 export { default as DialPressEvent } from './DialPressEvent';
 export { default as DialRotateEvent } from './DialRotateEvent';
+export { default as DialUpEvent } from './DialUpEvent';
 export { default as TouchTapEvent } from './TouchTapEvent';

--- a/src/Events/Received/Plugin/ReceivedPluginEventTypes.ts
+++ b/src/Events/Received/Plugin/ReceivedPluginEventTypes.ts
@@ -14,7 +14,13 @@ import {
   WillAppearEvent,
   WillDisappearEvent,
 } from '@/Events/Received/Plugin';
-import { DialPressEvent, DialRotateEvent, TouchTapEvent } from '@/Events/Received/Plugin/Dial';
+import {
+  DialDownEvent,
+  DialPressEvent,
+  DialRotateEvent,
+  DialUpEvent,
+  TouchTapEvent,
+} from '@/Events/Received/Plugin/Dial';
 
 export type ReceivedPluginEventTypes =
   | ReceivedEventTypes
@@ -22,8 +28,10 @@ export type ReceivedPluginEventTypes =
   | ApplicationDidTerminateEvent
   | DeviceDidConnectEvent
   | DeviceDidDisconnectEvent
+  | DialDownEvent
   | DialPressEvent
   | DialRotateEvent
+  | DialUpEvent
   | KeyDownEvent
   | KeyUpEvent
   | PropertyInspectorDidAppearEvent

--- a/src/Events/Received/Plugin/index.ts
+++ b/src/Events/Received/Plugin/index.ts
@@ -3,7 +3,7 @@ export { default as ApplicationDidTerminateEvent } from './ApplicationDidTermina
 export { default as DeviceDidConnectEvent } from './DeviceDidConnectEvent';
 export { default as DeviceDidDisconnectEvent } from './DeviceDidDisconnectEvent';
 export { DeviceType } from './DeviceType';
-export { DialPressEvent, DialRotateEvent, TouchTapEvent } from './Dial';
+export { DialDownEvent, DialPressEvent, DialRotateEvent, DialUpEvent, TouchTapEvent } from './Dial';
 export { default as KeyDownEvent } from './KeyDownEvent';
 export { default as KeyUpEvent } from './KeyUpEvent';
 export { default as PropertyInspectorDidAppearEvent } from './PropertyInspectorDidAppearEvent';

--- a/src/StreamdeckTypes/Received/Feedback/Components/PlaccardFeedbackComponent.ts
+++ b/src/StreamdeckTypes/Received/Feedback/Components/PlaccardFeedbackComponent.ts
@@ -2,6 +2,10 @@ import { Static, Type } from '@sinclair/typebox';
 
 import { BaseFeedbackComponentProperties } from './BaseFeedbackComponent';
 
+/**
+ * @deprecated The Placcard feedback component has been marked as deprecated in SDK 6.1 and will be removed in a future
+ * version of the SDK. Users seeking its functionality should use the `pixmap` component without setting an image.
+ */
 export const PlaccardFeedbackComponentProperties = {
   ...BaseFeedbackComponentProperties,
 
@@ -14,5 +18,15 @@ export const PlaccardFeedbackComponentProperties = {
     ]),
   ),
 };
+
+/**
+ * @deprecated The Placcard feedback component has been marked as deprecated in SDK 6.1 and will be removed in a future
+ * version of the SDK. Users seeking its functionality should use the `pixmap` component without setting an image.
+ */
 export const PlaccardFeedbackComponent = Type.Object(PlaccardFeedbackComponentProperties);
+
+/**
+ * @deprecated The Placcard feedback component has been marked as deprecated in SDK 6.1 and will be removed in a future
+ * version of the SDK. Users seeking its functionality should use the `pixmap` component without setting an image.
+ */
 export type PlaccardFeedbackComponent = Static<typeof PlaccardFeedbackComponent>;

--- a/src/StreamdeckTypes/Sent/Dial/DialDownEventType.ts
+++ b/src/StreamdeckTypes/Sent/Dial/DialDownEventType.ts
@@ -1,0 +1,16 @@
+import { Static, Type } from '@sinclair/typebox';
+
+import { BaseDialPayloadProperties, BaseDialProperties } from './BaseDialType';
+
+export const DialDownPayloadProperties = {
+  ...BaseDialPayloadProperties,
+};
+
+export const DialDownEventProperties = {
+  ...BaseDialProperties,
+  event: Type.RegEx(/^dialDown$/),
+  payload: Type.Object(DialDownPayloadProperties),
+};
+
+export const DialDownEventType = Type.Object(DialDownEventProperties);
+export type DialDownEventType = Static<typeof DialDownEventType>;

--- a/src/StreamdeckTypes/Sent/Dial/DialPressEventType.ts
+++ b/src/StreamdeckTypes/Sent/Dial/DialPressEventType.ts
@@ -2,15 +2,32 @@ import { Static, Type } from '@sinclair/typebox';
 
 import { BaseEncoderPayloadProperties, BaseEncoderProperties } from './BaseEncoderType';
 
+/**
+ * @deprecated The `dialPress` event was deprecated in Stream Deck SDK 6.1, and will be removed in a future version. It
+ * has been replaced by the `dialDown` and `dialUp` events.
+ */
 export const DialPressPayloadProperties = {
   ...BaseEncoderPayloadProperties,
 };
 
+/**
+ * @deprecated The `dialPress` event was deprecated in Stream Deck SDK 6.1, and will be removed in a future version. It
+ * has been replaced by the `dialDown` and `dialUp` events.
+ */
 export const DialPressEventProperties = {
   ...BaseEncoderProperties,
   event: Type.RegEx(/^dialPress$/),
   payload: Type.Object(DialPressPayloadProperties),
 };
 
+/**
+ * @deprecated The `dialPress` event was deprecated in Stream Deck SDK 6.1, and will be removed in a future version. It
+ * has been replaced by the `dialDown` and `dialUp` events.
+ */
 export const DialPressEventType = Type.Object(DialPressEventProperties);
+
+/**
+ * @deprecated The `dialPress` event was deprecated in Stream Deck SDK 6.1, and will be removed in a future version. It
+ * has been replaced by the `dialDown` and `dialUp` events.
+ */
 export type DialPressEventType = Static<typeof DialPressEventType>;

--- a/src/StreamdeckTypes/Sent/Dial/DialUpEventType.ts
+++ b/src/StreamdeckTypes/Sent/Dial/DialUpEventType.ts
@@ -1,0 +1,16 @@
+import { Static, Type } from '@sinclair/typebox';
+
+import { BaseDialPayloadProperties, BaseDialProperties } from './BaseDialType';
+
+export const DialUpPayloadProperties = {
+  ...BaseDialPayloadProperties,
+};
+
+export const DialUpEventProperties = {
+  ...BaseDialProperties,
+  event: Type.RegEx(/^dialUp$/),
+  payload: Type.Object(DialUpPayloadProperties),
+};
+
+export const DialUpEventType = Type.Object(DialUpEventProperties);
+export type DialUpEventType = Static<typeof DialUpEventType>;

--- a/src/StreamdeckTypes/Sent/Dial/index.ts
+++ b/src/StreamdeckTypes/Sent/Dial/index.ts
@@ -1,2 +1,4 @@
+export * from './DialDownEventType';
 export * from './DialPressEventType';
 export * from './DialRotateEventType';
+export * from './DialUpEventType';

--- a/test/Events/Received/EventFactoryTest.ts
+++ b/test/Events/Received/EventFactoryTest.ts
@@ -11,6 +11,8 @@ import {
   ApplicationDidTerminateEvent,
   DeviceDidConnectEvent,
   DeviceDidDisconnectEvent,
+  DialDownEvent,
+  DialUpEvent,
   KeyDownEvent,
   KeyUpEvent,
   PropertyInspectorDidAppearEvent,
@@ -28,9 +30,10 @@ import eventAppDidLaunch from './fixtures/applicationDidLaunchEvent.valid.json';
 import eventAppDidTerminate from './fixtures/applicationDidTerminateEvent.valid.json';
 import eventDeviceconnect from './fixtures/deviceDidConnectEvent.valid.json';
 import eventDeviceDisconnect from './fixtures/deviceDidDisconnectEvent.valid.json';
-// dial events
+import eventDialDown from './fixtures/dialDownEvent/valid.json';
 import eventDialPress from './fixtures/dialPressEvent/valid.json';
 import eventDialRotate from './fixtures/dialRotateEvent/valid.json';
+import eventDialUp from './fixtures/dialUpEvent/valid.json';
 import eventDidReceiveGlobalSettings from './fixtures/didReceiveGlobalSettingsEvent.valid.json';
 import eventDidReceiveSettings from './fixtures/didReceiveSettingsEvent.valid.json';
 import eventKeydown from './fixtures/keyDownEvent.valid.json';
@@ -140,5 +143,13 @@ describe('EventFactory test', () => {
 
   it('should return a touchTap event', () => {
     expect(new EventFactory().createByEventPayload(eventTouchTap)).to.be.instanceOf(TouchTapEvent);
+  });
+
+  it('should return a dialDown event', () => {
+    expect(new EventFactory().createByEventPayload(eventDialDown)).to.be.instanceOf(DialDownEvent);
+  });
+
+  it('should return a dialUp event', () => {
+    expect(new EventFactory().createByEventPayload(eventDialUp)).to.be.instanceOf(DialUpEvent);
   });
 });

--- a/test/Events/Received/Plugin/DialDownEventTest.ts
+++ b/test/Events/Received/Plugin/DialDownEventTest.ts
@@ -1,0 +1,37 @@
+import 'mocha';
+
+import { expect } from 'chai';
+
+import EventValidationError from '@/Events/Received/Exception/EventValidationError';
+import DialDownEvent from '@/Events/Received/Plugin/Dial/DialDownEvent';
+
+import eventInvalidType from '../fixtures/dialDownEvent/invalidEvent.json';
+import eventValid from '../fixtures/dialDownEvent/valid.json';
+
+describe('DialDownEvent test', () => {
+  it('should create the event when using the correct payload', function () {
+    const event = new DialDownEvent(eventValid);
+    expect(event.action).to.equal('ts.streamdeck.events.dialDownTest');
+    expect(event.context).to.equal('FEDCBA9876543210FEDCBA9876543210');
+    expect(event.device).to.equal('0123456789ABCDEF0123456789ABCDEF');
+    expect(event.event).to.equal('dialDown');
+    expect(event.column).to.equal(1);
+    expect(event.row).to.equal(0);
+    expect(event.controller).to.equal('Encoder');
+  });
+  it('should create the event with settings', function () {
+    const event = new DialDownEvent(eventValid);
+
+    expect(event.settings).to.haveOwnProperty('key');
+    expect((event.settings as { key: string }).key).to.equal('value');
+
+    expect(event.settings).to.haveOwnProperty('someNum');
+    expect((event.settings as { someNum: number }).someNum).to.equal(1234);
+  });
+  it('should throw a validation error on wrong event type', function () {
+    expect(() => new DialDownEvent(eventInvalidType)).to.throw(
+      EventValidationError,
+      /must match pattern "\^dialDown\$"/,
+    );
+  });
+});

--- a/test/Events/Received/Plugin/DialUpEventTest.ts
+++ b/test/Events/Received/Plugin/DialUpEventTest.ts
@@ -1,0 +1,34 @@
+import 'mocha';
+
+import { expect } from 'chai';
+
+import EventValidationError from '@/Events/Received/Exception/EventValidationError';
+import DialUpEvent from '@/Events/Received/Plugin/Dial/DialUpEvent';
+
+import eventInvalidType from '../fixtures/dialUpEvent/invalidEvent.json';
+import eventValid from '../fixtures/dialUpEvent/valid.json';
+
+describe('DialUpEvent test', () => {
+  it('should create the event when using the correct payload', function () {
+    const event = new DialUpEvent(eventValid);
+    expect(event.action).to.equal('ts.streamdeck.events.dialUpTest');
+    expect(event.context).to.equal('FEDCBA9876543210FEDCBA9876543210');
+    expect(event.device).to.equal('0123456789ABCDEF0123456789ABCDEF');
+    expect(event.event).to.equal('dialUp');
+    expect(event.column).to.equal(1);
+    expect(event.row).to.equal(0);
+    expect(event.controller).to.equal('Encoder');
+  });
+  it('should create the event with settings', function () {
+    const event = new DialUpEvent(eventValid);
+
+    expect(event.settings).to.haveOwnProperty('key');
+    expect((event.settings as { key: string }).key).to.equal('value');
+
+    expect(event.settings).to.haveOwnProperty('someNum');
+    expect((event.settings as { someNum: number }).someNum).to.equal(1234);
+  });
+  it('should throw a validation error on wrong event type', function () {
+    expect(() => new DialUpEvent(eventInvalidType)).to.throw(EventValidationError, /must match pattern "\^dialUp\$"/);
+  });
+});

--- a/test/Events/Received/fixtures/dialDownEvent/invalidEvent.json
+++ b/test/Events/Received/fixtures/dialDownEvent/invalidEvent.json
@@ -1,0 +1,17 @@
+{
+  "action": "ts.streamdeck.events.dialDownTest",
+  "context": "FEDCBA9876543210FEDCBA9876543210",
+  "device": "0123456789ABCDEF0123456789ABCDEF",
+  "event": "theTwinning",
+  "payload": {
+    "controller": "Encoder",
+    "coordinates": {
+      "column": 1,
+      "row": 0
+    },
+    "settings": {
+      "key": "value",
+      "someNum": 1234
+    }
+  }
+}

--- a/test/Events/Received/fixtures/dialDownEvent/valid.json
+++ b/test/Events/Received/fixtures/dialDownEvent/valid.json
@@ -1,0 +1,17 @@
+{
+  "action": "ts.streamdeck.events.dialDownTest",
+  "context": "FEDCBA9876543210FEDCBA9876543210",
+  "device": "0123456789ABCDEF0123456789ABCDEF",
+  "event": "dialDown",
+  "payload": {
+    "controller": "Encoder",
+    "coordinates": {
+      "column": 1,
+      "row": 0
+    },
+    "settings": {
+      "key": "value",
+      "someNum": 1234
+    }
+  }
+}

--- a/test/Events/Received/fixtures/dialUpEvent/invalidEvent.json
+++ b/test/Events/Received/fixtures/dialUpEvent/invalidEvent.json
@@ -1,0 +1,17 @@
+{
+  "action": "ts.streamdeck.events.dialUpTest",
+  "context": "FEDCBA9876543210FEDCBA9876543210",
+  "device": "0123456789ABCDEF0123456789ABCDEF",
+  "event": "malikahsWell",
+  "payload":{
+    "controller": "Encoder",
+    "coordinates": {
+      "column": 2,
+      "row": 0
+    },
+    "settings": {
+      "key": "value",
+      "someNum": 1234
+    }
+  }
+}

--- a/test/Events/Received/fixtures/dialUpEvent/valid.json
+++ b/test/Events/Received/fixtures/dialUpEvent/valid.json
@@ -1,0 +1,17 @@
+{
+  "action": "ts.streamdeck.events.dialUpTest",
+  "context": "FEDCBA9876543210FEDCBA9876543210",
+  "device": "0123456789ABCDEF0123456789ABCDEF",
+  "event": "dialUp",
+  "payload": {
+    "controller": "Encoder",
+    "coordinates": {
+      "column": 1,
+      "row": 0
+    },
+    "settings": {
+      "key": "value",
+      "someNum": 1234
+    }
+  }
+}


### PR DESCRIPTION
Rolling in the changes from [Stream Deck SDK Version 6.1](https://docs.elgato.com/sdk/plugins/changelog#changes-in-stream-deck-6.1):

- Add support for the `dialDown` and `dialUp` events, which replace `dialPressed`
- Mark `placcard` as deprecated in favor of `pixmap`

For now, I've opted to keep `BaseEncoderType` (and keep `DialRotateEventType` inheriting from this). Once Elgato removes `dialPress` entirely, it should be safe to remove this event and move dialRotate under BaseDialType. I can do this now as well if preferred, but I'm unsure if that would qualify as a breaking change.

Apologies if the linter complains, been a bit!